### PR TITLE
Feature: add XMLBoardAction, datetime converters, external format func, refacto and config testsuites

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -586,6 +586,14 @@ json-logging = ["json-logging"]
 test = ["pytest", "coverage", "requests", "nbval", "selenium", "pytest-cov", "requests-unixsocket"]
 
 [[package]]
+name = "numpy"
+version = "1.19.5"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -595,6 +603,22 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pandas"
+version = "0.25.3"
+description = "Powerful data structures for data analysis, time series, and statistics"
+category = "dev"
+optional = false
+python-versions = ">=3.5.3"
+
+[package.dependencies]
+numpy = ">=1.13.3"
+python-dateutil = ">=2.6.1"
+pytz = ">=2017.2"
+
+[package.extras]
+test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
 name = "pandocfilters"
@@ -801,6 +825,14 @@ description = "File type identification using libmagic"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pytz"
+version = "2021.3"
+description = "World timezone definitions, modern and historical"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "pywin32"
@@ -1080,7 +1112,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "a756795ebb45daa34fe089dab9f1314b77d8bb6cee7018142d7011682a3f8efe"
+content-hash = "7187a66d52bf0848ca4ba0b9974b25ef76462bbd924182be584acd4fb5fd0cad"
 
 [metadata.files]
 appdirs = [
@@ -1335,9 +1367,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
@@ -1349,9 +1378,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1363,9 +1389,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
@@ -1378,9 +1401,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1393,9 +1413,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1428,9 +1445,66 @@ notebook = [
     {file = "notebook-6.4.6-py3-none-any.whl", hash = "sha256:5cad068fa82cd4fb98d341c052100ed50cd69fbfb4118cb9b8ab5a346ef27551"},
     {file = "notebook-6.4.6.tar.gz", hash = "sha256:7bcdf79bd1cda534735bd9830d2cbedab4ee34d8fe1df6e7b946b3aab0902ba3"},
 ]
+numpy = [
+    {file = "numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff"},
+    {file = "numpy-1.19.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:aeb9ed923be74e659984e321f609b9ba54a48354bfd168d21a2b072ed1e833ea"},
+    {file = "numpy-1.19.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8b5e972b43c8fc27d56550b4120fe6257fdc15f9301914380b27f74856299fea"},
+    {file = "numpy-1.19.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:43d4c81d5ffdff6bae58d66a3cd7f54a7acd9a0e7b18d97abb255defc09e3140"},
+    {file = "numpy-1.19.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:a4646724fba402aa7504cd48b4b50e783296b5e10a524c7a6da62e4a8ac9698d"},
+    {file = "numpy-1.19.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:2e55195bc1c6b705bfd8ad6f288b38b11b1af32f3c8289d6c50d47f950c12e76"},
+    {file = "numpy-1.19.5-cp36-cp36m-win32.whl", hash = "sha256:39b70c19ec771805081578cc936bbe95336798b7edf4732ed102e7a43ec5c07a"},
+    {file = "numpy-1.19.5-cp36-cp36m-win_amd64.whl", hash = "sha256:dbd18bcf4889b720ba13a27ec2f2aac1981bd41203b3a3b27ba7a33f88ae4827"},
+    {file = "numpy-1.19.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:603aa0706be710eea8884af807b1b3bc9fb2e49b9f4da439e76000f3b3c6ff0f"},
+    {file = "numpy-1.19.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:cae865b1cae1ec2663d8ea56ef6ff185bad091a5e33ebbadd98de2cfa3fa668f"},
+    {file = "numpy-1.19.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:36674959eed6957e61f11c912f71e78857a8d0604171dfd9ce9ad5cbf41c511c"},
+    {file = "numpy-1.19.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:06fab248a088e439402141ea04f0fffb203723148f6ee791e9c75b3e9e82f080"},
+    {file = "numpy-1.19.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6149a185cece5ee78d1d196938b2a8f9d09f5a5ebfbba66969302a778d5ddd1d"},
+    {file = "numpy-1.19.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:50a4a0ad0111cc1b71fa32dedd05fa239f7fb5a43a40663269bb5dc7877cfd28"},
+    {file = "numpy-1.19.5-cp37-cp37m-win32.whl", hash = "sha256:d051ec1c64b85ecc69531e1137bb9751c6830772ee5c1c426dbcfe98ef5788d7"},
+    {file = "numpy-1.19.5-cp37-cp37m-win_amd64.whl", hash = "sha256:a12ff4c8ddfee61f90a1633a4c4afd3f7bcb32b11c52026c92a12e1325922d0d"},
+    {file = "numpy-1.19.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cf2402002d3d9f91c8b01e66fbb436a4ed01c6498fffed0e4c7566da1d40ee1e"},
+    {file = "numpy-1.19.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1ded4fce9cfaaf24e7a0ab51b7a87be9038ea1ace7f34b841fe3b6894c721d1c"},
+    {file = "numpy-1.19.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:012426a41bc9ab63bb158635aecccc7610e3eff5d31d1eb43bc099debc979d94"},
+    {file = "numpy-1.19.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:759e4095edc3c1b3ac031f34d9459fa781777a93ccc633a472a5468587a190ff"},
+    {file = "numpy-1.19.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:a9d17f2be3b427fbb2bce61e596cf555d6f8a56c222bd2ca148baeeb5e5c783c"},
+    {file = "numpy-1.19.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:99abf4f353c3d1a0c7a5f27699482c987cf663b1eac20db59b8c7b061eabd7fc"},
+    {file = "numpy-1.19.5-cp38-cp38-win32.whl", hash = "sha256:384ec0463d1c2671170901994aeb6dce126de0a95ccc3976c43b0038a37329c2"},
+    {file = "numpy-1.19.5-cp38-cp38-win_amd64.whl", hash = "sha256:811daee36a58dc79cf3d8bdd4a490e4277d0e4b7d103a001a4e73ddb48e7e6aa"},
+    {file = "numpy-1.19.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c843b3f50d1ab7361ca4f0b3639bf691569493a56808a0b0c54a051d260b7dbd"},
+    {file = "numpy-1.19.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d6631f2e867676b13026e2846180e2c13c1e11289d67da08d71cacb2cd93d4aa"},
+    {file = "numpy-1.19.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7fb43004bce0ca31d8f13a6eb5e943fa73371381e53f7074ed21a4cb786c32f8"},
+    {file = "numpy-1.19.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2ea52bd92ab9f768cc64a4c3ef8f4b2580a17af0a5436f6126b08efbd1838371"},
+    {file = "numpy-1.19.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:400580cbd3cff6ffa6293df2278c75aef2d58d8d93d3c5614cd67981dae68ceb"},
+    {file = "numpy-1.19.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:df609c82f18c5b9f6cb97271f03315ff0dbe481a2a02e56aeb1b1a985ce38e60"},
+    {file = "numpy-1.19.5-cp39-cp39-win32.whl", hash = "sha256:ab83f24d5c52d60dbc8cd0528759532736b56db58adaa7b5f1f76ad551416a1e"},
+    {file = "numpy-1.19.5-cp39-cp39-win_amd64.whl", hash = "sha256:0eef32ca3132a48e43f6a0f5a82cb508f22ce5a3d6f67a8329c81c8e226d3f6e"},
+    {file = "numpy-1.19.5-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:a0d53e51a6cb6f0d9082decb7a4cb6dfb33055308c4c44f53103c073f649af73"},
+    {file = "numpy-1.19.5.zip", hash = "sha256:a76f502430dd98d7546e1ea2250a7360c065a5fdea52b2dffe8ae7180909b6f4"},
+]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pandas = [
+    {file = "pandas-0.25.3-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:df8864824b1fe488cf778c3650ee59c3a0d8f42e53707de167ba6b4f7d35f133"},
+    {file = "pandas-0.25.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7458c48e3d15b8aaa7d575be60e1e4dd70348efcd9376656b72fecd55c59a4c3"},
+    {file = "pandas-0.25.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:61741f5aeb252f39c3031d11405305b6d10ce663c53bc3112705d7ad66c013d0"},
+    {file = "pandas-0.25.3-cp35-cp35m-win32.whl", hash = "sha256:adc3d3a3f9e59a38d923e90e20c4922fc62d1e5a03d083440468c6d8f3f1ae0a"},
+    {file = "pandas-0.25.3-cp35-cp35m-win_amd64.whl", hash = "sha256:975c461accd14e89d71772e89108a050fa824c0b87a67d34cedf245f6681fc17"},
+    {file = "pandas-0.25.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ee50c2142cdcf41995655d499a157d0a812fce55c97d9aad13bc1eef837ed36c"},
+    {file = "pandas-0.25.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:4545467a637e0e1393f7d05d61dace89689ad6d6f66f267f86fff737b702cce9"},
+    {file = "pandas-0.25.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bbe3eb765a0b1e578833d243e2814b60c825b7fdbf4cdfe8e8aae8a08ed56ecf"},
+    {file = "pandas-0.25.3-cp36-cp36m-win32.whl", hash = "sha256:8153705d6545fd9eb6dd2bc79301bff08825d2e2f716d5dced48daafc2d0b81f"},
+    {file = "pandas-0.25.3-cp36-cp36m-win_amd64.whl", hash = "sha256:26382aab9c119735908d94d2c5c08020a4a0a82969b7e5eefb92f902b3b30ad7"},
+    {file = "pandas-0.25.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:00dff3a8e337f5ed7ad295d98a31821d3d0fe7792da82d78d7fd79b89c03ea9d"},
+    {file = "pandas-0.25.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e45055c30a608076e31a9fcd780a956ed3b1fa20db61561b8d88b79259f526f7"},
+    {file = "pandas-0.25.3-cp37-cp37m-win32.whl", hash = "sha256:255920e63850dc512ce356233081098554d641ba99c3767dde9e9f35630f994b"},
+    {file = "pandas-0.25.3-cp37-cp37m-win_amd64.whl", hash = "sha256:22361b1597c8c2ffd697aa9bf85423afa9e1fcfa6b1ea821054a244d5f24d75e"},
+    {file = "pandas-0.25.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9962957a27bfb70ab64103d0a7b42fa59c642fb4ed4cb75d0227b7bb9228535d"},
+    {file = "pandas-0.25.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:78bf638993219311377ce9836b3dc05f627a666d0dbc8cec37c0ff3c9ada673b"},
+    {file = "pandas-0.25.3-cp38-cp38-win32.whl", hash = "sha256:6a3ac2c87e4e32a969921d1428525f09462770c349147aa8e9ab95f88c71ec71"},
+    {file = "pandas-0.25.3-cp38-cp38-win_amd64.whl", hash = "sha256:33970f4cacdd9a0ddb8f21e151bfb9f178afb7c36eb7c25b9094c02876f385c2"},
+    {file = "pandas-0.25.3.tar.gz", hash = "sha256:52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4"},
 ]
 pandocfilters = [
     {file = "pandocfilters-1.5.0-py2.py3-none-any.whl", hash = "sha256:33aae3f25fd1a026079f5d27bdd52496f0e0803b3469282162bafdcbdf6ef14f"},
@@ -1547,6 +1621,10 @@ python-magic = [
     {file = "python-magic-0.4.24.tar.gz", hash = "sha256:de800df9fb50f8ec5974761054a708af6e4246b03b4bdaee993f948947b0ebcf"},
     {file = "python_magic-0.4.24-py2.py3-none-any.whl", hash = "sha256:4fec8ee805fea30c07afccd1592c0f17977089895bdfaae5fec870a84e997626"},
 ]
+pytz = [
+    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
+    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
+]
 pywin32 = [
     {file = "pywin32-302-cp310-cp310-win32.whl", hash = "sha256:251b7a9367355ccd1a4cd69cd8dd24bd57b29ad83edb2957cfa30f7ed9941efa"},
     {file = "pywin32-302-cp310-cp310-win_amd64.whl", hash = "sha256:79cf7e6ddaaf1cd47a9e50cc74b5d770801a9db6594464137b1b86aa91edafcc"},
@@ -1573,32 +1651,24 @@ pyzmq = [
     {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f89468059ebc519a7acde1ee50b779019535db8dcf9b8c162ef669257fef7a93"},
     {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea12133df25e3a6918718fbb9a510c6ee5d3fdd5a346320421aac3882f4feeea"},
     {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76c532fd68b93998aab92356be280deec5de8f8fe59cd28763d2cc8a58747b7f"},
-    {file = "pyzmq-22.3.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f907c7359ce8bf7f7e63c82f75ad0223384105f5126f313400b7e8004d9b33c3"},
-    {file = "pyzmq-22.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:902319cfe23366595d3fa769b5b751e6ee6750a0a64c5d9f757d624b2ac3519e"},
     {file = "pyzmq-22.3.0-cp310-cp310-win32.whl", hash = "sha256:67db33bea0a29d03e6eeec55a8190e033318cee3cbc732ba8fd939617cbf762d"},
     {file = "pyzmq-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:7661fc1d5cb73481cf710a1418a4e1e301ed7d5d924f91c67ba84b2a1b89defd"},
     {file = "pyzmq-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79244b9e97948eaf38695f4b8e6fc63b14b78cc37f403c6642ba555517ac1268"},
     {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab888624ed68930442a3f3b0b921ad7439c51ba122dbc8c386e6487a658e4a4e"},
     {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:18cd854b423fce44951c3a4d3e686bac8f1243d954f579e120a1714096637cc0"},
     {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:de8df0684398bd74ad160afdc2a118ca28384ac6f5e234eb0508858d8d2d9364"},
-    {file = "pyzmq-22.3.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:62bcade20813796c426409a3e7423862d50ff0639f5a2a95be4b85b09a618666"},
-    {file = "pyzmq-22.3.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ea5a79e808baef98c48c884effce05c31a0698c1057de8fc1c688891043c1ce1"},
     {file = "pyzmq-22.3.0-cp36-cp36m-win32.whl", hash = "sha256:3c1895c95be92600233e476fe283f042e71cf8f0b938aabf21b7aafa62a8dac9"},
     {file = "pyzmq-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:851977788b9caa8ed011f5f643d3ee8653af02c5fc723fa350db5125abf2be7b"},
     {file = "pyzmq-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4ebed0977f92320f6686c96e9e8dd29eed199eb8d066936bac991afc37cbb70"},
     {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42abddebe2c6a35180ca549fadc7228d23c1e1f76167c5ebc8a936b5804ea2df"},
     {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1e41b32d6f7f9c26bc731a8b529ff592f31fc8b6ef2be9fa74abd05c8a342d7"},
     {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:be4e0f229cf3a71f9ecd633566bd6f80d9fa6afaaff5489492be63fe459ef98c"},
-    {file = "pyzmq-22.3.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:08c4e315a76ef26eb833511ebf3fa87d182152adf43dedee8d79f998a2162a0b"},
-    {file = "pyzmq-22.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:badb868fff14cfd0e200eaa845887b1011146a7d26d579aaa7f966c203736b92"},
     {file = "pyzmq-22.3.0-cp37-cp37m-win32.whl", hash = "sha256:7c58f598d9fcc52772b89a92d72bf8829c12d09746a6d2c724c5b30076c1f11d"},
     {file = "pyzmq-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2b97502c16a5ec611cd52410bdfaab264997c627a46b0f98d3f666227fd1ea2d"},
     {file = "pyzmq-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d728b08448e5ac3e4d886b165385a262883c34b84a7fe1166277fe675e1c197a"},
     {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:480b9931bfb08bf8b094edd4836271d4d6b44150da051547d8c7113bf947a8b0"},
     {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7dc09198e4073e6015d9a8ea093fc348d4e59de49382476940c3dd9ae156fba8"},
     {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ca6cd58f62a2751728016d40082008d3b3412a7f28ddfb4a2f0d3c130f69e74"},
-    {file = "pyzmq-22.3.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:468bd59a588e276961a918a3060948ae68f6ff5a7fa10bb2f9160c18fe341067"},
-    {file = "pyzmq-22.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c88fa7410e9fc471e0858638f403739ee869924dd8e4ae26748496466e27ac59"},
     {file = "pyzmq-22.3.0-cp38-cp38-win32.whl", hash = "sha256:c0f84360dcca3481e8674393bdf931f9f10470988f87311b19d23cda869bb6b7"},
     {file = "pyzmq-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:f762442bab706fd874064ca218b33a1d8e40d4938e96c24dafd9b12e28017f45"},
     {file = "pyzmq-22.3.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:954e73c9cd4d6ae319f1c936ad159072b6d356a92dcbbabfd6e6204b9a79d356"},
@@ -1606,8 +1676,6 @@ pyzmq = [
     {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:acebba1a23fb9d72b42471c3771b6f2f18dcd46df77482612054bd45c07dfa36"},
     {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cf98fd7a6c8aaa08dbc699ffae33fd71175696d78028281bc7b832b26f00ca57"},
     {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d072f7dfbdb184f0786d63bda26e8a0882041b1e393fbe98940395f7fab4c5e2"},
-    {file = "pyzmq-22.3.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:53f4fd13976789ffafedd4d46f954c7bb01146121812b72b4ddca286034df966"},
-    {file = "pyzmq-22.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d1b5d457acbadcf8b27561deeaa386b0217f47626b29672fa7bd31deb6e91e1b"},
     {file = "pyzmq-22.3.0-cp39-cp39-win32.whl", hash = "sha256:e6a02cf7271ee94674a44f4e62aa061d2d049001c844657740e156596298b70b"},
     {file = "pyzmq-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:d3dcb5548ead4f1123851a5ced467791f6986d68c656bc63bfff1bf9e36671e2"},
     {file = "pyzmq-22.3.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3a4c9886d61d386b2b493377d980f502186cd71d501fffdba52bd2a0880cef4f"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -586,14 +586,6 @@ json-logging = ["json-logging"]
 test = ["pytest", "coverage", "requests", "nbval", "selenium", "pytest-cov", "requests-unixsocket"]
 
 [[package]]
-name = "numpy"
-version = "1.19.5"
-description = "NumPy is the fundamental package for array computing with Python."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -603,22 +595,6 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
-
-[[package]]
-name = "pandas"
-version = "0.25.3"
-description = "Powerful data structures for data analysis, time series, and statistics"
-category = "dev"
-optional = false
-python-versions = ">=3.5.3"
-
-[package.dependencies]
-numpy = ">=1.13.3"
-python-dateutil = ">=2.6.1"
-pytz = ">=2017.2"
-
-[package.extras]
-test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
 name = "pandocfilters"
@@ -825,14 +801,6 @@ description = "File type identification using libmagic"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
-name = "pytz"
-version = "2021.3"
-description = "World timezone definitions, modern and historical"
-category = "dev"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "pywin32"
@@ -1112,7 +1080,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "7187a66d52bf0848ca4ba0b9974b25ef76462bbd924182be584acd4fb5fd0cad"
+content-hash = "a756795ebb45daa34fe089dab9f1314b77d8bb6cee7018142d7011682a3f8efe"
 
 [metadata.files]
 appdirs = [
@@ -1445,66 +1413,9 @@ notebook = [
     {file = "notebook-6.4.6-py3-none-any.whl", hash = "sha256:5cad068fa82cd4fb98d341c052100ed50cd69fbfb4118cb9b8ab5a346ef27551"},
     {file = "notebook-6.4.6.tar.gz", hash = "sha256:7bcdf79bd1cda534735bd9830d2cbedab4ee34d8fe1df6e7b946b3aab0902ba3"},
 ]
-numpy = [
-    {file = "numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff"},
-    {file = "numpy-1.19.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:aeb9ed923be74e659984e321f609b9ba54a48354bfd168d21a2b072ed1e833ea"},
-    {file = "numpy-1.19.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8b5e972b43c8fc27d56550b4120fe6257fdc15f9301914380b27f74856299fea"},
-    {file = "numpy-1.19.5-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:43d4c81d5ffdff6bae58d66a3cd7f54a7acd9a0e7b18d97abb255defc09e3140"},
-    {file = "numpy-1.19.5-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:a4646724fba402aa7504cd48b4b50e783296b5e10a524c7a6da62e4a8ac9698d"},
-    {file = "numpy-1.19.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:2e55195bc1c6b705bfd8ad6f288b38b11b1af32f3c8289d6c50d47f950c12e76"},
-    {file = "numpy-1.19.5-cp36-cp36m-win32.whl", hash = "sha256:39b70c19ec771805081578cc936bbe95336798b7edf4732ed102e7a43ec5c07a"},
-    {file = "numpy-1.19.5-cp36-cp36m-win_amd64.whl", hash = "sha256:dbd18bcf4889b720ba13a27ec2f2aac1981bd41203b3a3b27ba7a33f88ae4827"},
-    {file = "numpy-1.19.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:603aa0706be710eea8884af807b1b3bc9fb2e49b9f4da439e76000f3b3c6ff0f"},
-    {file = "numpy-1.19.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:cae865b1cae1ec2663d8ea56ef6ff185bad091a5e33ebbadd98de2cfa3fa668f"},
-    {file = "numpy-1.19.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:36674959eed6957e61f11c912f71e78857a8d0604171dfd9ce9ad5cbf41c511c"},
-    {file = "numpy-1.19.5-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:06fab248a088e439402141ea04f0fffb203723148f6ee791e9c75b3e9e82f080"},
-    {file = "numpy-1.19.5-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6149a185cece5ee78d1d196938b2a8f9d09f5a5ebfbba66969302a778d5ddd1d"},
-    {file = "numpy-1.19.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:50a4a0ad0111cc1b71fa32dedd05fa239f7fb5a43a40663269bb5dc7877cfd28"},
-    {file = "numpy-1.19.5-cp37-cp37m-win32.whl", hash = "sha256:d051ec1c64b85ecc69531e1137bb9751c6830772ee5c1c426dbcfe98ef5788d7"},
-    {file = "numpy-1.19.5-cp37-cp37m-win_amd64.whl", hash = "sha256:a12ff4c8ddfee61f90a1633a4c4afd3f7bcb32b11c52026c92a12e1325922d0d"},
-    {file = "numpy-1.19.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cf2402002d3d9f91c8b01e66fbb436a4ed01c6498fffed0e4c7566da1d40ee1e"},
-    {file = "numpy-1.19.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1ded4fce9cfaaf24e7a0ab51b7a87be9038ea1ace7f34b841fe3b6894c721d1c"},
-    {file = "numpy-1.19.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:012426a41bc9ab63bb158635aecccc7610e3eff5d31d1eb43bc099debc979d94"},
-    {file = "numpy-1.19.5-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:759e4095edc3c1b3ac031f34d9459fa781777a93ccc633a472a5468587a190ff"},
-    {file = "numpy-1.19.5-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:a9d17f2be3b427fbb2bce61e596cf555d6f8a56c222bd2ca148baeeb5e5c783c"},
-    {file = "numpy-1.19.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:99abf4f353c3d1a0c7a5f27699482c987cf663b1eac20db59b8c7b061eabd7fc"},
-    {file = "numpy-1.19.5-cp38-cp38-win32.whl", hash = "sha256:384ec0463d1c2671170901994aeb6dce126de0a95ccc3976c43b0038a37329c2"},
-    {file = "numpy-1.19.5-cp38-cp38-win_amd64.whl", hash = "sha256:811daee36a58dc79cf3d8bdd4a490e4277d0e4b7d103a001a4e73ddb48e7e6aa"},
-    {file = "numpy-1.19.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c843b3f50d1ab7361ca4f0b3639bf691569493a56808a0b0c54a051d260b7dbd"},
-    {file = "numpy-1.19.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d6631f2e867676b13026e2846180e2c13c1e11289d67da08d71cacb2cd93d4aa"},
-    {file = "numpy-1.19.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7fb43004bce0ca31d8f13a6eb5e943fa73371381e53f7074ed21a4cb786c32f8"},
-    {file = "numpy-1.19.5-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:2ea52bd92ab9f768cc64a4c3ef8f4b2580a17af0a5436f6126b08efbd1838371"},
-    {file = "numpy-1.19.5-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:400580cbd3cff6ffa6293df2278c75aef2d58d8d93d3c5614cd67981dae68ceb"},
-    {file = "numpy-1.19.5-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:df609c82f18c5b9f6cb97271f03315ff0dbe481a2a02e56aeb1b1a985ce38e60"},
-    {file = "numpy-1.19.5-cp39-cp39-win32.whl", hash = "sha256:ab83f24d5c52d60dbc8cd0528759532736b56db58adaa7b5f1f76ad551416a1e"},
-    {file = "numpy-1.19.5-cp39-cp39-win_amd64.whl", hash = "sha256:0eef32ca3132a48e43f6a0f5a82cb508f22ce5a3d6f67a8329c81c8e226d3f6e"},
-    {file = "numpy-1.19.5-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:a0d53e51a6cb6f0d9082decb7a4cb6dfb33055308c4c44f53103c073f649af73"},
-    {file = "numpy-1.19.5.zip", hash = "sha256:a76f502430dd98d7546e1ea2250a7360c065a5fdea52b2dffe8ae7180909b6f4"},
-]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
-]
-pandas = [
-    {file = "pandas-0.25.3-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:df8864824b1fe488cf778c3650ee59c3a0d8f42e53707de167ba6b4f7d35f133"},
-    {file = "pandas-0.25.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7458c48e3d15b8aaa7d575be60e1e4dd70348efcd9376656b72fecd55c59a4c3"},
-    {file = "pandas-0.25.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:61741f5aeb252f39c3031d11405305b6d10ce663c53bc3112705d7ad66c013d0"},
-    {file = "pandas-0.25.3-cp35-cp35m-win32.whl", hash = "sha256:adc3d3a3f9e59a38d923e90e20c4922fc62d1e5a03d083440468c6d8f3f1ae0a"},
-    {file = "pandas-0.25.3-cp35-cp35m-win_amd64.whl", hash = "sha256:975c461accd14e89d71772e89108a050fa824c0b87a67d34cedf245f6681fc17"},
-    {file = "pandas-0.25.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ee50c2142cdcf41995655d499a157d0a812fce55c97d9aad13bc1eef837ed36c"},
-    {file = "pandas-0.25.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:4545467a637e0e1393f7d05d61dace89689ad6d6f66f267f86fff737b702cce9"},
-    {file = "pandas-0.25.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bbe3eb765a0b1e578833d243e2814b60c825b7fdbf4cdfe8e8aae8a08ed56ecf"},
-    {file = "pandas-0.25.3-cp36-cp36m-win32.whl", hash = "sha256:8153705d6545fd9eb6dd2bc79301bff08825d2e2f716d5dced48daafc2d0b81f"},
-    {file = "pandas-0.25.3-cp36-cp36m-win_amd64.whl", hash = "sha256:26382aab9c119735908d94d2c5c08020a4a0a82969b7e5eefb92f902b3b30ad7"},
-    {file = "pandas-0.25.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:00dff3a8e337f5ed7ad295d98a31821d3d0fe7792da82d78d7fd79b89c03ea9d"},
-    {file = "pandas-0.25.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e45055c30a608076e31a9fcd780a956ed3b1fa20db61561b8d88b79259f526f7"},
-    {file = "pandas-0.25.3-cp37-cp37m-win32.whl", hash = "sha256:255920e63850dc512ce356233081098554d641ba99c3767dde9e9f35630f994b"},
-    {file = "pandas-0.25.3-cp37-cp37m-win_amd64.whl", hash = "sha256:22361b1597c8c2ffd697aa9bf85423afa9e1fcfa6b1ea821054a244d5f24d75e"},
-    {file = "pandas-0.25.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9962957a27bfb70ab64103d0a7b42fa59c642fb4ed4cb75d0227b7bb9228535d"},
-    {file = "pandas-0.25.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:78bf638993219311377ce9836b3dc05f627a666d0dbc8cec37c0ff3c9ada673b"},
-    {file = "pandas-0.25.3-cp38-cp38-win32.whl", hash = "sha256:6a3ac2c87e4e32a969921d1428525f09462770c349147aa8e9ab95f88c71ec71"},
-    {file = "pandas-0.25.3-cp38-cp38-win_amd64.whl", hash = "sha256:33970f4cacdd9a0ddb8f21e151bfb9f178afb7c36eb7c25b9094c02876f385c2"},
-    {file = "pandas-0.25.3.tar.gz", hash = "sha256:52da74df8a9c9a103af0a72c9d5fdc8e0183a90884278db7f386b5692a2220a4"},
 ]
 pandocfilters = [
     {file = "pandocfilters-1.5.0-py2.py3-none-any.whl", hash = "sha256:33aae3f25fd1a026079f5d27bdd52496f0e0803b3469282162bafdcbdf6ef14f"},
@@ -1621,10 +1532,6 @@ python-magic = [
     {file = "python-magic-0.4.24.tar.gz", hash = "sha256:de800df9fb50f8ec5974761054a708af6e4246b03b4bdaee993f948947b0ebcf"},
     {file = "python_magic-0.4.24-py2.py3-none-any.whl", hash = "sha256:4fec8ee805fea30c07afccd1592c0f17977089895bdfaae5fec870a84e997626"},
 ]
-pytz = [
-    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
-    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
-]
 pywin32 = [
     {file = "pywin32-302-cp310-cp310-win32.whl", hash = "sha256:251b7a9367355ccd1a4cd69cd8dd24bd57b29ad83edb2957cfa30f7ed9941efa"},
     {file = "pywin32-302-cp310-cp310-win_amd64.whl", hash = "sha256:79cf7e6ddaaf1cd47a9e50cc74b5d770801a9db6594464137b1b86aa91edafcc"},
@@ -1651,24 +1558,32 @@ pyzmq = [
     {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f89468059ebc519a7acde1ee50b779019535db8dcf9b8c162ef669257fef7a93"},
     {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ea12133df25e3a6918718fbb9a510c6ee5d3fdd5a346320421aac3882f4feeea"},
     {file = "pyzmq-22.3.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:76c532fd68b93998aab92356be280deec5de8f8fe59cd28763d2cc8a58747b7f"},
+    {file = "pyzmq-22.3.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:f907c7359ce8bf7f7e63c82f75ad0223384105f5126f313400b7e8004d9b33c3"},
+    {file = "pyzmq-22.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:902319cfe23366595d3fa769b5b751e6ee6750a0a64c5d9f757d624b2ac3519e"},
     {file = "pyzmq-22.3.0-cp310-cp310-win32.whl", hash = "sha256:67db33bea0a29d03e6eeec55a8190e033318cee3cbc732ba8fd939617cbf762d"},
     {file = "pyzmq-22.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:7661fc1d5cb73481cf710a1418a4e1e301ed7d5d924f91c67ba84b2a1b89defd"},
     {file = "pyzmq-22.3.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79244b9e97948eaf38695f4b8e6fc63b14b78cc37f403c6642ba555517ac1268"},
     {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab888624ed68930442a3f3b0b921ad7439c51ba122dbc8c386e6487a658e4a4e"},
     {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:18cd854b423fce44951c3a4d3e686bac8f1243d954f579e120a1714096637cc0"},
     {file = "pyzmq-22.3.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:de8df0684398bd74ad160afdc2a118ca28384ac6f5e234eb0508858d8d2d9364"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:62bcade20813796c426409a3e7423862d50ff0639f5a2a95be4b85b09a618666"},
+    {file = "pyzmq-22.3.0-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:ea5a79e808baef98c48c884effce05c31a0698c1057de8fc1c688891043c1ce1"},
     {file = "pyzmq-22.3.0-cp36-cp36m-win32.whl", hash = "sha256:3c1895c95be92600233e476fe283f042e71cf8f0b938aabf21b7aafa62a8dac9"},
     {file = "pyzmq-22.3.0-cp36-cp36m-win_amd64.whl", hash = "sha256:851977788b9caa8ed011f5f643d3ee8653af02c5fc723fa350db5125abf2be7b"},
     {file = "pyzmq-22.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b4ebed0977f92320f6686c96e9e8dd29eed199eb8d066936bac991afc37cbb70"},
     {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42abddebe2c6a35180ca549fadc7228d23c1e1f76167c5ebc8a936b5804ea2df"},
     {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1e41b32d6f7f9c26bc731a8b529ff592f31fc8b6ef2be9fa74abd05c8a342d7"},
     {file = "pyzmq-22.3.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:be4e0f229cf3a71f9ecd633566bd6f80d9fa6afaaff5489492be63fe459ef98c"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:08c4e315a76ef26eb833511ebf3fa87d182152adf43dedee8d79f998a2162a0b"},
+    {file = "pyzmq-22.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:badb868fff14cfd0e200eaa845887b1011146a7d26d579aaa7f966c203736b92"},
     {file = "pyzmq-22.3.0-cp37-cp37m-win32.whl", hash = "sha256:7c58f598d9fcc52772b89a92d72bf8829c12d09746a6d2c724c5b30076c1f11d"},
     {file = "pyzmq-22.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:2b97502c16a5ec611cd52410bdfaab264997c627a46b0f98d3f666227fd1ea2d"},
     {file = "pyzmq-22.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d728b08448e5ac3e4d886b165385a262883c34b84a7fe1166277fe675e1c197a"},
     {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:480b9931bfb08bf8b094edd4836271d4d6b44150da051547d8c7113bf947a8b0"},
     {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7dc09198e4073e6015d9a8ea093fc348d4e59de49382476940c3dd9ae156fba8"},
     {file = "pyzmq-22.3.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0ca6cd58f62a2751728016d40082008d3b3412a7f28ddfb4a2f0d3c130f69e74"},
+    {file = "pyzmq-22.3.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:468bd59a588e276961a918a3060948ae68f6ff5a7fa10bb2f9160c18fe341067"},
+    {file = "pyzmq-22.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c88fa7410e9fc471e0858638f403739ee869924dd8e4ae26748496466e27ac59"},
     {file = "pyzmq-22.3.0-cp38-cp38-win32.whl", hash = "sha256:c0f84360dcca3481e8674393bdf931f9f10470988f87311b19d23cda869bb6b7"},
     {file = "pyzmq-22.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:f762442bab706fd874064ca218b33a1d8e40d4938e96c24dafd9b12e28017f45"},
     {file = "pyzmq-22.3.0-cp39-cp39-macosx_10_15_universal2.whl", hash = "sha256:954e73c9cd4d6ae319f1c936ad159072b6d356a92dcbbabfd6e6204b9a79d356"},
@@ -1676,6 +1591,8 @@ pyzmq = [
     {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:acebba1a23fb9d72b42471c3771b6f2f18dcd46df77482612054bd45c07dfa36"},
     {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cf98fd7a6c8aaa08dbc699ffae33fd71175696d78028281bc7b832b26f00ca57"},
     {file = "pyzmq-22.3.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d072f7dfbdb184f0786d63bda26e8a0882041b1e393fbe98940395f7fab4c5e2"},
+    {file = "pyzmq-22.3.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:53f4fd13976789ffafedd4d46f954c7bb01146121812b72b4ddca286034df966"},
+    {file = "pyzmq-22.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d1b5d457acbadcf8b27561deeaa386b0217f47626b29672fa7bd31deb6e91e1b"},
     {file = "pyzmq-22.3.0-cp39-cp39-win32.whl", hash = "sha256:e6a02cf7271ee94674a44f4e62aa061d2d049001c844657740e156596298b70b"},
     {file = "pyzmq-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:d3dcb5548ead4f1123851a5ced467791f6986d68c656bc63bfff1bf9e36671e2"},
     {file = "pyzmq-22.3.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3a4c9886d61d386b2b493377d980f502186cd71d501fffdba52bd2a0880cef4f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ pytest-cov = "^3.0.0"
 black = "20.8b0"
 unittest = "^0.0"
 responses = "^0.16.0"
-pandas = "0.25.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ pytest-cov = "^3.0.0"
 black = "20.8b0"
 unittest = "^0.0"
 responses = "^0.16.0"
+pandas = "0.25.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts=--ignore=tests/connectors --cov=src/hrflow_connectors/core --cov=src/hrflow_connectors/utils --cov-report=xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ project_urls =
 
 # Change if running only on Windows, Mac or Linux (comma-separated)
 platforms = any
-python_requires = >=3.6
 version = attr: VERSION
 
 # Add here all kinds of additional classifiers as defined under
@@ -43,7 +42,7 @@ package_dir =
     =src
 
 # Require a min/specific Python version (comma-separated conditions)
-# python_requires = >=3.6
+python_requires = >=3.6
 
 # Add here dependencies of your project (line-separated), e.g. requests>=2.2,<3.0.
 # Version specifiers like >=2.2,<3.0 avoid problems due to API changes in

--- a/src/hrflow_connectors/connectors/boards/xml/actions.py
+++ b/src/hrflow_connectors/connectors/boards/xml/actions.py
@@ -1,0 +1,45 @@
+from ....core.action import BoardAction
+from ....core.http import HTTPStream
+
+
+from pydantic import Field
+import xml.etree.ElementTree
+from typing import Iterator
+
+
+class XMLBoardAction(BoardAction, HTTPStream):
+    xml_stream_url: str = Field(..., description="URL to XML Stream")
+    job_list_xpath: str = Field(
+        ..., description="XPath pointing to the job list in the XML stream"
+    )
+
+    @property
+    def base_url(self):
+        return self.xml_stream_url
+
+    @property
+    def http_method(self):
+        return "GET"
+
+    def get_all_references_from_stream(self):
+        input_data = self.pull()
+        filtered_data = self.apply_logics(input_data)
+        formated_data = map(self.format, filtered_data)
+        references_iter = map(lambda job: job.get("reference"), formated_data)
+        references_without_none_iter = filter(
+            lambda ref: ref is not None, references_iter
+        )
+        return references_without_none_iter
+
+    def pull(self) -> Iterator[xml.etree.ElementTree.Element]:
+        response = self.send_request()
+
+        if response.status_code >= 400:
+            error_message = "Unable to pull the data ! Reason : `{}`"
+            raise ConnectionError(error_message.format(response.content))
+
+        xml_stream = response.content
+        root_element = xml.etree.ElementTree.fromstring(xml_stream)
+        job_list_element = root_element.find(self.job_list_xpath)
+        job_list = list(job_list_element)
+        return job_list

--- a/src/hrflow_connectors/core/action.py
+++ b/src/hrflow_connectors/core/action.py
@@ -17,6 +17,10 @@ class Action(BaseModel):
     global_scope: Dict[str, Any] = None
     local_scope: Dict[str, Any] = None
 
+    format_function_name: Optional[str] = Field(
+        None, description="Function name to format job before pushing"
+    )
+
     workflow_catch: bool = Field(
         True,
         const=True,
@@ -59,12 +63,20 @@ class Action(BaseModel):
         For example to select and transform only some fields from a database to Hrflow.
         This function must adapt the data schema passed in (from the `pull`) to the expected data schema in output (ready to be used in the `pull` function)
 
+        If the `format_function_name` attribute is initialized with the name of a function,
+        then it will be executed instead of the `format` method of the connector.
+
         Args:
             data (TalentDataType): Data we want to adapt to the output format
 
         Returns:
             Dict[str, Any]: Data adapted to the input format of the pull function, ready to be sent
         """
+        if self.format is not None:
+            format_function = eval(
+                self.format_function_name, self.global_scope, self.local_scope
+            )
+            return format_function(data)
         return data
 
     def push(self, data: Iterator[Union[str, Dict[str, Any]]]):

--- a/src/hrflow_connectors/core/action.py
+++ b/src/hrflow_connectors/core/action.py
@@ -72,7 +72,7 @@ class Action(BaseModel):
         Returns:
             Dict[str, Any]: Data adapted to the input format of the pull function, ready to be sent
         """
-        if self.format is not None:
+        if self.format_function_name is not None:
             format_function = eval(
                 self.format_function_name, self.global_scope, self.local_scope
             )

--- a/src/hrflow_connectors/utils/datetime_converter.py
+++ b/src/hrflow_connectors/utils/datetime_converter.py
@@ -1,0 +1,87 @@
+import datetime
+import re
+from typing import Union
+
+class ParseError(ValueError):
+    """
+    Parse Error
+    """
+    def __init__(self, message):            
+        super().__init__(message)
+
+class DateFormatError(ParseError):
+    """
+    Date Format Error
+    """
+    def __init__(self, value):            
+        super().__init__("Le format de la date ne respecte pas la norme ISO8601 : `{}`".format(value))
+
+
+def any_to_int(any : Union[None, str]) -> int:
+    """
+    Convert int string to integer. if this value is `None`, return `0`
+    Args:
+        any (Union[None, str]): value to convert
+    Returns:
+        int: converted integer
+    """
+    if any is None:
+        return 0
+    return int(any)
+
+def from_str_to_datetime(datetime_str: str) -> datetime.datetime:
+    """
+    Convert string to `datetime.datetime`.
+    The date must respect ISO8601 format.
+    Args:
+        datetime_str (str): date formated with the norme ISO8601
+    Raises:
+        DateFormatError: "Le format de la date ne respecte pas la norme ISO8601 : ..."
+    Returns:
+        datetime.datetime: converted Datetime object
+    """
+    isoformat_regex = "^(?P<year>\d{4})(-|/)(?P<month>\d{2})(-|/)(?P<day>\d{2})(.(?P<hour>\d{2})(:(?P<minute>\d{2})(:(?P<second>\d{2})(\.(?P<millisecond>\d{1,6}))?)?)?)?(?P<tz>((?P<tz_symbol>-|\+)(?P<tz_hour>\d{2}):?(?P<tz_minute>\d{2})(:(?P<tz_second>\d{2})(\.(?P<tz_millisecond>\d{1,6}))?)?)|Z)?$"
+    match = re.search(isoformat_regex, datetime_str)
+    if not match:
+        raise DateFormatError(datetime_str)
+
+    # Extract value from string
+    ## Datetime
+    year, month, day = match.group("year", "month", "day")
+    hour, minute, second, millisecond = match.group("hour", "minute", "second", "millisecond")
+
+    ## TimeZone
+    tz_field_in_str = match.group("tz")# example : +02:00
+    tz_symbol = match.group("tz_symbol")
+    tz_hour, tz_minute, tz_second, tz_millisecond = match.group("tz_hour", "tz_minute", "tz_second", "tz_millisecond")
+
+    # Pad right with 0 the fields millisecond and tz_millisecond
+    # "123" => "123000"
+    if millisecond is not None:
+        millisecond = millisecond.ljust(6, "0")
+    if tz_millisecond is not None:
+        tz_millisecond = tz_millisecond.ljust(6, "0")
+
+    # Convert each field to int
+    try:
+        year, month, day = any_to_int(year), any_to_int(month), any_to_int(day)
+        hour, minute, second, millisecond = any_to_int(hour), any_to_int(minute), any_to_int(second), any_to_int(millisecond)
+        tz_hour, tz_minute, tz_second, tz_millisecond = any_to_int(tz_hour), any_to_int(tz_minute), any_to_int(tz_second), any_to_int(tz_millisecond)
+    except ValueError:
+        raise DateFormatError(datetime_str)
+
+    # Convert to Object
+    delta = datetime.timedelta(hours=tz_hour, minutes=tz_minute, seconds=tz_second, microseconds=tz_millisecond)
+    if tz_symbol == "-":
+        # when -HH:MM
+        delta = -1 * delta
+    
+    timezone = datetime.timezone(delta)
+
+    if tz_field_in_str is None:
+        timezone = None
+    
+    try:
+        return datetime.datetime(year=year, month=month, day=day, hour=hour, minute=minute, second=second, microsecond=millisecond, tzinfo=timezone)
+    except ValueError:
+        raise DateFormatError(datetime_str)

--- a/src/hrflow_connectors/utils/timedelta_converter.py
+++ b/src/hrflow_connectors/utils/timedelta_converter.py
@@ -1,0 +1,90 @@
+import datetime
+import re
+from typing import Union
+
+
+class ParseError(ValueError):
+    """
+    Parse Error
+    """
+
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class TimeDeltaFormatError(ParseError):
+    """
+    TimeDelta Format Error
+    """
+
+    def __init__(self, value):
+        super().__init__(
+            "Le format de la durée ne respecte pas le format `[[-]DD days, ]HH:MM:SS[.mmmmmm]`. Example : `-1804 days, 15:54:03.999990` or `8:02:12` : `{}`".format(
+                value
+            )
+        )
+
+
+def any_to_int(any: Union[None, str]) -> int:
+    """
+    Convert int string to integer. if this value is `None`, return `0`
+    Args:
+        any (Union[None, str]): value to convert
+    Returns:
+        int: converted integer
+    """
+    if any is None:
+        return 0
+    return int(any)
+
+
+def from_str_to_timedelta(timedelta_str: str) -> datetime.timedelta:
+    """
+    Convert string to `datetime.timedelta`.
+    The date must respect the format `[[-]DD days, ]HH:MM:SS[.mmmmmm]`.
+    Examples : `-1804 days, 15:54:03.999990` or `8:02:12`
+    Args:
+        datetime_str (str): formated timedelta
+    Raises:
+        TimeDeltaFormatError: Le format de la durée ne respecte pas le format `[[-]DD days, ]HH:MM:SS[.mmmmmm]`. Example : `-1804 days, 15:54:03.999990` or `8:02:12` : ..."
+    Returns:
+        datetime.timedelta: converted TimeDelta object
+    """
+    isoformat_regex = "^((?P<day>[-0-9]+) day(s)?, )?(?P<hour>\d+):(?P<minute>\d+):(?P<second>\d+)(\.(?P<millisecond>\d{1,6}))?$"
+    match = re.search(isoformat_regex, timedelta_str)
+    if not match:
+        raise TimeDeltaFormatError(timedelta_str)
+
+    # Extract value from string
+    day, hour, minute, second, millisecond = match.group(
+        "day", "hour", "minute", "second", "millisecond"
+    )
+
+    # Pad right with 0 the fields millisecond
+    # "123" => "123000"
+    if millisecond is not None:
+        millisecond = millisecond.ljust(6, "0")
+
+    # Convert each field to int
+    try:
+        day, hour, minute, second, millisecond = (
+            any_to_int(day),
+            any_to_int(hour),
+            any_to_int(minute),
+            any_to_int(second),
+            any_to_int(millisecond),
+        )
+    except ValueError:
+        raise TimeDeltaFormatError(timedelta_str)
+
+    # Convert to Object
+    try:
+        return datetime.timedelta(
+            days=day,
+            hours=hour,
+            minutes=minute,
+            seconds=second,
+            microseconds=millisecond,
+        )
+    except ValueError:
+        raise TimeDeltaFormatError(timedelta_str)

--- a/tests/connectors/boards/crosstalent/test_get_all_jobs.py
+++ b/tests/connectors/boards/crosstalent/test_get_all_jobs.py
@@ -3,16 +3,13 @@ import json
 import pytest
 from hrflow import Hrflow
 
-import hrflow_connectors as hc
 from hrflow_connectors.core.auth import OAuth2PasswordCredentialsBody
 from hrflow_connectors.connectors.boards.crosstalent.actions import GetAllJobs
 
-ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(hc.__file__), "../../"))
-
 
 @pytest.fixture
-def credentials():
-    with open(os.path.join(ROOT_PATH, "credentials.json"), "r") as f:
+def credentials(pytestconfig):
+    with open(os.path.join(pytestconfig.rootpath, "credentials.json"), "r") as f:
         credentials = json.loads(f.read())
     return credentials
 

--- a/tests/connectors/boards/indeed/test_indeed_feed.py
+++ b/tests/connectors/boards/indeed/test_indeed_feed.py
@@ -3,15 +3,12 @@ import json
 import pytest
 from hrflow import Hrflow
 
-import hrflow_connectors as hc
 from hrflow_connectors.connectors.boards.indeed.actions import IndeedFeed
-
-ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(hc.__file__), "../../"))
 
 
 @pytest.fixture
-def credentials():
-    with open(os.path.join(ROOT_PATH, "credentials.json"), "r") as f:
+def credentials(pytestconfig):
+    with open(os.path.join(pytestconfig.rootpath, "credentials.json"), "r") as f:
         credentials = json.loads(f.read())
     return credentials
 
@@ -24,11 +21,14 @@ def hrflow_client(credentials):
     return client
 
 
-def test_IndeedFeed(hrflow_client):
-    executable_path = os.path.join(ROOT_PATH, "src/hrflow_connectors/connectors/boards/indeed/chromedriver_linux64/chromedriver")
+def test_IndeedFeed(hrflow_client, pytestconfig):
+    executable_path = os.path.join(
+        pytestconfig.rootpath,
+        "src/hrflow_connectors/connectors/boards/indeed/chromedriver_linux64/chromedriver",
+    )
     action = IndeedFeed(
         executable_path=executable_path,
-        max_page = 2,
+        max_page=2,
         subdomain="fr",
         hrflow_client=hrflow_client,
         job_search="Software Engineer",

--- a/tests/connectors/boards/xml/test_samsic.py
+++ b/tests/connectors/boards/xml/test_samsic.py
@@ -1,0 +1,164 @@
+from hrflow_connectors.connectors.boards.xml.actions import XMLBoardAction
+from hrflow_connectors.utils.datetime_converter import from_str_to_datetime
+
+import os
+import json
+import pytest
+from hrflow import Hrflow
+
+import hrflow_connectors as hc
+
+ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(hc.__file__), "../../"))
+
+
+@pytest.fixture
+def credentials():
+    with open(os.path.join(ROOT_PATH, "credentials.json"), "r") as f:
+        credentials = json.loads(f.read())
+    return credentials
+
+
+@pytest.fixture
+def hrflow_client(credentials):
+    def hrflow_client_func(portal_name="dev-demo"):
+        x_api_key = credentials["hrflow"][portal_name]["x-api-key"]
+        x_user_email = credentials["hrflow"][portal_name]["x-user-email"]
+        client = Hrflow(api_secret=x_api_key, api_user=x_user_email)
+        return client
+
+    return hrflow_client_func
+
+
+def test_get_all_jobs_from_samsic_xml_stream(hrflow_client):
+    def samsic_format(data):
+        job = dict()
+
+        # name
+        job["name"] = data.findtext("Title")
+
+        # reference
+        job["reference"] = data.findtext("Reference")
+
+        # created_at
+        created_at_str = data.findtext("PublicationDateISO")
+        created_at_datetime = from_str_to_datetime(created_at_str)
+        job["created_at"] = created_at_datetime.isoformat()
+
+        # url
+        job["url"] = data.findtext(
+            "PostingInstruction/ApplicationMethod/Communication/Text"
+        )
+
+        # location
+        ## TODO ajouter utils de Zipcode -> Coords
+        lat = None
+        lng = None
+        location_label_list = [
+            "Location/CountryCode",
+            "Location/City",
+            "Location/PostalCode",
+            "Location/Address",
+        ]
+        location_text_list = [
+            data.findtext(label, default="") for label in location_label_list
+        ]
+        location_text = " ".join(location_text_list)
+
+        geojson = dict()
+        geojson["city"] = data.findtext("Location/City")
+        geojson["country"] = data.findtext("Location/CountryCode")
+
+        postcode = data.findtext("Location/PostalCode")
+
+        geojson["postcode"] = postcode
+
+        job["location"] = dict(lat=lat, lng=lng, text=location_text, geojson=geojson)
+
+        # summary
+        job["summary"] = data.findtext("Description")
+
+        # sections
+        job["sections"] = []
+
+        def create_section(field_path: str, title: str = None):
+            """
+            Create a section in job if `field_name` value is not `None`
+
+            Args:
+                field_path (str): Field path used to retrieve value in the tree in Samsic. For example : `Organization/Description`
+                title (str, optional): Section title. Defaults to None.
+            """
+            field_name = field_path.replace("/", "-")
+            section_name = "samsic_{}".format(field_name)
+            section_title = title
+            section_description = data.findtext(field_path)
+            if section_description is not None:
+                section = dict(
+                    name=section_name,
+                    title=section_title,
+                    description=section_description,
+                )
+                job["sections"].append(section)
+
+        ## Add sections
+        create_section("Organization/Description", "Organization description")
+        create_section("Profile", "Profile")
+
+        # languages
+        job["languages"] = []
+
+        # tags
+        job["tags"] = []
+
+        def create_tag(field_path: str):
+            """
+            Create tag in job if `field_path` is not `None`
+
+            Args:
+                field_path (str): Field path used to retrieve value in the tree in Samsic. For example : `Organization/Description`
+            """
+            field_name = field_path.replace("/", "-")
+            tag_name = "crosstalent_{}".format(field_name)
+            tag_value = data.findtext(field_path)
+            if tag_value is not None:
+                tag = dict(name=tag_name, value=tag_value)
+                job["tags"].append(tag)
+
+        ## Add tags
+        create_tag("Duration")
+        create_tag("Organization/Name")
+        create_tag("Job")
+        create_tag("Contract")
+        create_tag("EducationRequirement")
+        create_tag("LineOfBusiness")
+        create_tag("FieldOfActivite")
+        create_tag("DrivingLicence")
+        create_tag("RequiredExperience")
+        create_tag("Remuneration")
+
+        start_date_str = data.findtext("StartDate")
+        start_date_datetime = from_str_to_datetime(start_date_str)
+        start_date_tag_value = start_date_datetime.isoformat()
+        start_date_tag = dict(name="samsic_StartDate", value=start_date_tag_value)
+        job["tags"].append(start_date_tag)
+
+        # metadatas
+        job["metadatas"] = []
+
+        return job
+
+    xml_stream_url = "https://cv.samsic-emploi.fr/media/flux/jobs.xml"
+    job_list_xpath = "DataArea"
+
+    action = XMLBoardAction(
+        xml_stream_url=xml_stream_url,
+        job_list_xpath=job_list_xpath,
+        hrflow_client=hrflow_client("dev-demo"),
+        board_key="ebf489eff6bef0e95ca03eb0d6ed8f8e030a634f",
+        hydrate_with_parsing=False,
+        archive_deleted_jobs_from_stream=False,
+        format_function_name="samsic_format",
+        global_scope=globals(),
+        local_scope=locals(),
+    )
+    action.execute()

--- a/tests/connectors/boards/xml/test_xml_board_action.py
+++ b/tests/connectors/boards/xml/test_xml_board_action.py
@@ -7,14 +7,10 @@ import pytest
 from hrflow import Hrflow
 import responses
 
-import hrflow_connectors as hc
-
-ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(hc.__file__), "../../"))
-
 
 @pytest.fixture
-def credentials():
-    with open(os.path.join(ROOT_PATH, "credentials.json"), "r") as f:
+def credentials(pytestconfig):
+    with open(os.path.join(pytestconfig.rootpath, "credentials.json"), "r") as f:
         credentials = json.loads(f.read())
     return credentials
 
@@ -164,6 +160,7 @@ def test_get_all_jobs_from_samsic_xml_stream(hrflow_client):
     )
     action.execute()
 
+
 @responses.activate
 def test_XMLBoardAction_pull_generic_xml_stream(hrflow_client):
     xml_stream_url = "https://test.test/job/xml_stream"
@@ -192,12 +189,7 @@ def test_XMLBoardAction_pull_generic_xml_stream(hrflow_client):
     </board>
 </all>"""
 
-    responses.add(
-        responses.GET,
-        xml_stream_url,
-        status=200,
-        body=xml_stream_str
-    )
+    responses.add(responses.GET, xml_stream_url, status=200, body=xml_stream_str)
 
     job_list_xpath = "board/jobs"
     action = XMLBoardAction(
@@ -206,7 +198,7 @@ def test_XMLBoardAction_pull_generic_xml_stream(hrflow_client):
         hrflow_client=hrflow_client("dev-demo"),
         board_key="abc",
         hydrate_with_parsing=False,
-        archive_deleted_jobs_from_stream=False
+        archive_deleted_jobs_from_stream=False,
     )
     xml_job_node_list = action.pull()
 
@@ -214,16 +206,16 @@ def test_XMLBoardAction_pull_generic_xml_stream(hrflow_client):
     job_node_1, job_node_2, job_node_3 = xml_job_node_list
 
     name_1, reference_1 = list(job_node_1)
-    assert job_node_1.attrib['data-id'] == "1"
+    assert job_node_1.attrib["data-id"] == "1"
     assert name_1.text == "Data scientist"
     assert reference_1.text == "ds42"
 
     name_2, reference_2 = list(job_node_2)
-    assert job_node_2.attrib['data-id'] == "2"
+    assert job_node_2.attrib["data-id"] == "2"
     assert name_2.text == "Software Engineer"
     assert reference_2.text == "se18"
 
     name_3, reference_3 = list(job_node_3)
-    assert job_node_3.attrib['data-id'] == "3"
+    assert job_node_3.attrib["data-id"] == "3"
     assert name_3.text == "Painter"
     assert reference_3.text == "pt56"

--- a/tests/connectors/destinations/crosstalent/test_push_profile.py
+++ b/tests/connectors/destinations/crosstalent/test_push_profile.py
@@ -3,17 +3,14 @@ import json
 import pytest
 from hrflow import Hrflow
 
-import hrflow_connectors as hc
 from hrflow_connectors.core.auth import OAuth2PasswordCredentialsBody
 from hrflow_connectors.connectors.destinations.crosstalent.actions import PushProfile
 from hrflow_connectors.utils.hrflow import Profile, Source
 
-ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(hc.__file__), "../../"))
-
 
 @pytest.fixture
-def credentials():
-    with open(os.path.join(ROOT_PATH, "credentials.json"), "r") as f:
+def credentials(pytestconfig):
+    with open(os.path.join(pytestconfig.rootpath, "credentials.json"), "r") as f:
         credentials = json.loads(f.read())
     return credentials
 

--- a/tests/core/test_action.py
+++ b/tests/core/test_action.py
@@ -76,6 +76,49 @@ def test_apply_logics_single_filter_without_interaction(generated_data_list):
     assert dict(element1="value2", element2="value2") in filtered_list
 
 
+def test_extern_format_function():
+    def extern_format(data):
+        return dict(c=data["a"], d=data["a"] + data["b"])
+
+    action = Action(
+        format_function_name="extern_format",
+        global_scope=globals(),
+        local_scope=locals(),
+    )
+
+    job_to_transform = dict(a="aaa", b="bbb", f="fff")
+    transformed_job = action.format(job_to_transform)
+    assert transformed_job == dict(c="aaa", d="aaabbb")
+
+
+def test_default_format_without_extern_format_function():
+    action = Action(
+        format_function_name=None,
+    )
+    job_to_transform = dict(a="aaa", b="bbb", f="fff")
+    transformed_job = action.format(job_to_transform)
+    assert transformed_job == dict(a="aaa", b="bbb", f="fff")
+
+
+def test_overwritten_format_with_extern_format_function():
+    def extern_format(data):
+        return dict(c=data["a"], d=data["a"] + data["b"])
+
+    class TestAction(Action):
+        def format(self, data):
+            return dict(f=data["f"], g=data["a"] + data["b"])
+
+    action = TestAction(
+        format_function_name="extern_format",
+        global_scope=globals(),
+        local_scope=locals(),
+    )
+
+    job_to_transform = dict(a="aaa", b="bbb", f="fff")
+    transformed_job = action.format(job_to_transform)
+    assert transformed_job == dict(f="fff", g="aaabbb")
+
+
 @responses.activate
 def test_Action_connect_and_execute(generated_data_list):
     # Build a connector from `generated_data_list` to `http://test.test/push`

--- a/tests/core/test_action.py
+++ b/tests/core/test_action.py
@@ -222,7 +222,7 @@ def test_BoardAction_hydrate_job_with_parsing(generated_parsing_text_response):
 @pytest.fixture
 def generate_indexing_get_response():
     def indexing_get_response_func(code, message, archived_at):
-        job = dict(archived_at=archived_at)
+        job = dict(key="klm", archived_at=archived_at)
         response = dict(code=code, message=message, data=job)
         return response
 
@@ -344,12 +344,22 @@ def test_BoardAction_check_reference_in_board_for_archived_job_in_board(
         json=generated_response,
     )
 
-    # create a matcher to check if the JSON Body sent by the Connector is in the right shape and has the right values
+    ## create a matcher to check if the JSON Body sent by the Connector is in the right shape and has the right values
     expected_body = dict(board_key="abc", reference="REF1", is_archive=False)
     match = [responses.matchers.json_params_matcher(expected_body)]
     responses.add(
         responses.PATCH,
         "https://api.hrflow.ai/v1/job/indexing/archive",
+        status=200,
+        match=match,
+    )
+
+    ## create a matcher to check if the JSON Body sent by the Connector is in the right shape and has the right values
+    expected_body = dict(board_key="abc", key="klm", reference="REF1")
+    match = [responses.matchers.json_params_matcher(expected_body)]
+    responses.add(
+        responses.PUT,
+        "https://api.hrflow.ai/v1/job/indexing",
         status=200,
         match=match,
     )

--- a/tests/utils/test_datetime_converter.py
+++ b/tests/utils/test_datetime_converter.py
@@ -3,131 +3,178 @@ from hrflow_connectors.utils.datetime_converter import (
     from_str_to_datetime,
     DateFormatError,
 )
-import pandas as pd
-
-
-def assert_datetime(datetime_string):
-    got = from_str_to_datetime(datetime_string)
-    expected = pd.to_datetime(datetime_string).to_pydatetime()
-    assert got == expected
 
 
 ## YYYY/MM/DD
 def test_simple_slash_date():
-    assert_datetime("2000/10/01")
+    got = from_str_to_datetime("2000/10/01")
+    expected = datetime.datetime(2000, 10, 1, 0, 0)
+    assert got == expected
 
 
 ### Separation : Space
 def test_simple_slash_date_space_with_hours():
-    assert_datetime("2000/10/01 12")
+    got = from_str_to_datetime("2000/10/01 12")
+    expected = datetime.datetime(2000, 10, 1, 12, 0)
+    assert got == expected
 
 
 def test_simple_slash_date_space_with_hours_minutes():
-    assert_datetime("2000/10/01 12:02")
+    got = from_str_to_datetime("2000/10/01 12:02")
+    expected = datetime.datetime(2000, 10, 1, 12, 2)
+    assert got == expected
 
 
 def test_simple_slash_date_space_with_hours_minutes_seconds():
-    assert_datetime("2000/10/01 12:02:14")
+    got = from_str_to_datetime("2000/10/01 12:02:14")
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14)
+    assert got == expected
 
 
 ### Separation : T
 def test_simple_slash_date_T_with_hours():
-    assert_datetime("2000/10/01T12")
+    got = from_str_to_datetime("2000/10/01T12")
+    expected = datetime.datetime(2000, 10, 1, 12, 0)
+    assert got == expected
 
 
 def test_simple_slash_date_T_with_hours_minutes():
-    assert_datetime("2000/10/01T12:02")
+    got = from_str_to_datetime("2000/10/01T12:02")
+    expected = datetime.datetime(2000, 10, 1, 12, 2)
+    assert got == expected
 
 
 def test_simple_slash_date_T_with_hours_minutes_seconds():
-    assert_datetime("2000/10/01T12:02:14")
+    got = from_str_to_datetime("2000/10/01T12:02:14")
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14)
+    assert got == expected
 
 
 ## YYYY-MM-DD
 def test_simple_hyphen_date():
-    assert_datetime("2000-10-01")
+    got = from_str_to_datetime("2000-10-01")
+    expected = datetime.datetime(2000, 10, 1, 0, 0)
+    assert got == expected
 
 
 ### Separation : Space
 def test_simple_hyphen_date_space_with_hours():
-    assert_datetime("2000-10-01 12")
+    got = from_str_to_datetime("2000-10-01 12")
+    expected = datetime.datetime(2000, 10, 1, 12, 0)
+    assert got == expected
 
 
 def test_simple_hyphen_date_space_with_hours_minutes():
-    assert_datetime("2000-10-01 12:02")
+    got = from_str_to_datetime("2000-10-01 12:02")
+    expected = datetime.datetime(2000, 10, 1, 12, 2)
+    assert got == expected
 
 
 def test_simple_hyphen_date_space_with_hours_minutes_seconds():
-    assert_datetime("2000-10-01 12:02:14")
+    got = from_str_to_datetime("2000-10-01 12:02:14")
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14)
+    assert got == expected
 
 
 def test_simple_hyphen_date_space_with_hours_minutes_seconds_milliseconds_short():
-    assert_datetime("2000-10-01 12:02:14.123")
+    got = from_str_to_datetime("2000-10-01 12:02:14.123")
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14, 123000)
+    assert got == expected
 
 
 def test_simple_hyphen_date_space_with_hours_minutes_seconds_milliseconds_long():
-    assert_datetime("2000-10-01 12:02:14.851541")
+    got = from_str_to_datetime("2000-10-01 12:02:14.851541")
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14, 851541)
+    assert got == expected
 
 
 ### Separation : T
 def test_simple_hyphen_date_T_with_hours():
-    assert_datetime("2000-10-01T12")
+    got = from_str_to_datetime("2000-10-01T12")
+    expected = datetime.datetime(2000, 10, 1, 12, 0)
+    assert got == expected
 
 
 def test_simple_hyphen_date_T_with_hours_minutes():
-    assert_datetime("2000-10-01T12:02")
+    got = from_str_to_datetime("2000-10-01T12:02")
+    expected = datetime.datetime(2000, 10, 1, 12, 2)
+    assert got == expected
 
 
 def test_simple_hyphen_date_T_with_hours_minutes_seconds():
-    assert_datetime("2000-10-01T12:02:14")
+    got = from_str_to_datetime("2000-10-01T12:02:14")
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14)
+    assert got == expected
 
 
 def test_simple_hyphen_date_T_with_hours_minutes_seconds_milliseconds_short():
-    assert_datetime("2000-10-01T12:02:14.123")
+    got = from_str_to_datetime("2000-10-01T12:02:14.123")
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14, 123000)
+    assert got == expected
 
 
 def test_simple_hyphen_date_T_with_hours_minutes_seconds_milliseconds_long():
-    assert_datetime("2000-10-01T12:02:14.851541")
+    got = from_str_to_datetime("2000-10-01T12:02:14.851541")
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14, 851541)
+    assert got == expected
 
 
 ## Time zone
 def test_simple_hyphen_date_T_with_hours_minutes_seconds_Z():
-    assert_datetime("2000-10-01T12:02:14Z")
+    got = from_str_to_datetime("2000-10-01T12:02:14Z")
+    tz = datetime.timezone.utc
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14, tzinfo=tz)
+    assert got == expected
 
 
 def test_simple_hyphen_date_T_with_hours_Z():
-    assert_datetime("2000-10-01T12Z")
+    got = from_str_to_datetime("2000-10-01T12Z")
+    tz = datetime.timezone.utc
+    expected = datetime.datetime(2000, 10, 1, 12, 0, tzinfo=tz)
+    assert got == expected
 
 
 def test_simple_hyphen_date_T_with_hours_minutes_seconds_milliseconds_long_plus_6_colons():
-    assert_datetime("2000-10-01T12:02:14.851541+06:00")
+    got = from_str_to_datetime("2000-10-01T12:02:14.851541+06:00")
+    tz = datetime.timezone(datetime.timedelta(hours=6))
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14, 851541, tzinfo=tz)
+    assert got == expected
 
 
 def test_simple_hyphen_date_T_with_hours_minutes_seconds_milliseconds_long_plus_8():
-    assert_datetime("2000-10-01T12:02:14.851541+0800")
+    got = from_str_to_datetime("2000-10-01T12:02:14.851541+0800")
+    tz = datetime.timezone(datetime.timedelta(hours=8))
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14, 851541, tzinfo=tz)
+    assert got == expected
 
 
 def test_simple_hyphen_date_T_with_hours_minutes_seconds_moins_3():
-    assert_datetime("2000-10-01T12:02:14-0300")
-
-
-def test_simple_hyphen_date_space_with_hours():
-    assert_datetime("2000-10-01 12")
+    got = from_str_to_datetime("2000-10-01T12:02:14-0300")
+    tz = datetime.timezone(datetime.timedelta(hours=-3))
+    expected = datetime.datetime(2000, 10, 1, 12, 2, 14, tzinfo=tz)
+    assert got == expected
 
 
 ## Random examples
-
-
-def test_simple_date_in_DR():
-    assert_datetime("2021-10-11T14:57:33+00:00")
+def test_simple_date_with_colons_in_timezone():
+    got = from_str_to_datetime("2021-10-11T14:57:33+00:00")
+    tz = datetime.timezone.utc
+    expected = datetime.datetime(2021, 10, 11, 14, 57, 33, tzinfo=tz)
+    assert got == expected
 
 
 def test_simple_date_in_HrFlow_tag():
-    assert_datetime("2021-10-13T10:57:38+0200")
+    got = from_str_to_datetime("2021-10-13T10:57:38+0200")
+    tz = datetime.timezone(datetime.timedelta(hours=2))
+    expected = datetime.datetime(2021, 10, 13, 10, 57, 38, tzinfo=tz)
+    assert got == expected
 
 
 def test_simple_date_in_HrFlow():
-    assert_datetime("2021-10-01T12:59:05+0000")
+    got = from_str_to_datetime("2021-10-01T12:59:05+0000")
+    tz = datetime.timezone.utc
+    expected = datetime.datetime(2021, 10, 1, 12, 59, 5, tzinfo=tz)
+    assert got == expected
 
 
 def test_wrong_date_with_letter():

--- a/tests/utils/test_datetime_converter.py
+++ b/tests/utils/test_datetime_converter.py
@@ -179,20 +179,20 @@ def test_simple_date_in_HrFlow():
 
 def test_wrong_date_with_letter():
     try:
-        assert_datetime("2021-1H-01T12:59:05+0000")
+        from_str_to_datetime("2021-1H-01T12:59:05+0000")
     except DateFormatError:
         pass
 
 
 def test_wrong_date_with_invalid_date():
     try:
-        assert_datetime("2021-10-32T12:59:05+0000")
+        from_str_to_datetime("2021-10-32T12:59:05+0000")
     except DateFormatError:
         pass
 
 
 def test_wrong_date_with_invalid_format():
     try:
-        assert_datetime("2021-10sssss")
+        from_str_to_datetime("2021-10sssss")
     except DateFormatError:
         pass

--- a/tests/utils/test_datetime_converter.py
+++ b/tests/utils/test_datetime_converter.py
@@ -1,0 +1,151 @@
+import datetime
+from hrflow_connectors.utils.datetime_converter import (
+    from_str_to_datetime,
+    DateFormatError,
+)
+import pandas as pd
+
+
+def assert_datetime(datetime_string):
+    got = from_str_to_datetime(datetime_string)
+    expected = pd.to_datetime(datetime_string).to_pydatetime()
+    assert got == expected
+
+
+## YYYY/MM/DD
+def test_simple_slash_date():
+    assert_datetime("2000/10/01")
+
+
+### Separation : Space
+def test_simple_slash_date_space_with_hours():
+    assert_datetime("2000/10/01 12")
+
+
+def test_simple_slash_date_space_with_hours_minutes():
+    assert_datetime("2000/10/01 12:02")
+
+
+def test_simple_slash_date_space_with_hours_minutes_seconds():
+    assert_datetime("2000/10/01 12:02:14")
+
+
+### Separation : T
+def test_simple_slash_date_T_with_hours():
+    assert_datetime("2000/10/01T12")
+
+
+def test_simple_slash_date_T_with_hours_minutes():
+    assert_datetime("2000/10/01T12:02")
+
+
+def test_simple_slash_date_T_with_hours_minutes_seconds():
+    assert_datetime("2000/10/01T12:02:14")
+
+
+## YYYY-MM-DD
+def test_simple_hyphen_date():
+    assert_datetime("2000-10-01")
+
+
+### Separation : Space
+def test_simple_hyphen_date_space_with_hours():
+    assert_datetime("2000-10-01 12")
+
+
+def test_simple_hyphen_date_space_with_hours_minutes():
+    assert_datetime("2000-10-01 12:02")
+
+
+def test_simple_hyphen_date_space_with_hours_minutes_seconds():
+    assert_datetime("2000-10-01 12:02:14")
+
+
+def test_simple_hyphen_date_space_with_hours_minutes_seconds_milliseconds_short():
+    assert_datetime("2000-10-01 12:02:14.123")
+
+
+def test_simple_hyphen_date_space_with_hours_minutes_seconds_milliseconds_long():
+    assert_datetime("2000-10-01 12:02:14.851541")
+
+
+### Separation : T
+def test_simple_hyphen_date_T_with_hours():
+    assert_datetime("2000-10-01T12")
+
+
+def test_simple_hyphen_date_T_with_hours_minutes():
+    assert_datetime("2000-10-01T12:02")
+
+
+def test_simple_hyphen_date_T_with_hours_minutes_seconds():
+    assert_datetime("2000-10-01T12:02:14")
+
+
+def test_simple_hyphen_date_T_with_hours_minutes_seconds_milliseconds_short():
+    assert_datetime("2000-10-01T12:02:14.123")
+
+
+def test_simple_hyphen_date_T_with_hours_minutes_seconds_milliseconds_long():
+    assert_datetime("2000-10-01T12:02:14.851541")
+
+
+## Time zone
+def test_simple_hyphen_date_T_with_hours_minutes_seconds_Z():
+    assert_datetime("2000-10-01T12:02:14Z")
+
+
+def test_simple_hyphen_date_T_with_hours_Z():
+    assert_datetime("2000-10-01T12Z")
+
+
+def test_simple_hyphen_date_T_with_hours_minutes_seconds_milliseconds_long_plus_6_colons():
+    assert_datetime("2000-10-01T12:02:14.851541+06:00")
+
+
+def test_simple_hyphen_date_T_with_hours_minutes_seconds_milliseconds_long_plus_8():
+    assert_datetime("2000-10-01T12:02:14.851541+0800")
+
+
+def test_simple_hyphen_date_T_with_hours_minutes_seconds_moins_3():
+    assert_datetime("2000-10-01T12:02:14-0300")
+
+
+def test_simple_hyphen_date_space_with_hours():
+    assert_datetime("2000-10-01 12")
+
+
+## Random examples
+
+
+def test_simple_date_in_DR():
+    assert_datetime("2021-10-11T14:57:33+00:00")
+
+
+def test_simple_date_in_HrFlow_tag():
+    assert_datetime("2021-10-13T10:57:38+0200")
+
+
+def test_simple_date_in_HrFlow():
+    assert_datetime("2021-10-01T12:59:05+0000")
+
+
+def test_wrong_date_with_letter():
+    try:
+        assert_datetime("2021-1H-01T12:59:05+0000")
+    except DateFormatError:
+        pass
+
+
+def test_wrong_date_with_invalid_date():
+    try:
+        assert_datetime("2021-10-32T12:59:05+0000")
+    except DateFormatError:
+        pass
+
+
+def test_wrong_date_with_invalid_format():
+    try:
+        assert_datetime("2021-10sssss")
+    except DateFormatError:
+        pass

--- a/tests/utils/test_timedelta_converter.py
+++ b/tests/utils/test_timedelta_converter.py
@@ -1,15 +1,14 @@
-import datetime
 from hrflow_connectors.utils.timedelta_converter import (
     from_str_to_timedelta,
     TimeDeltaFormatError,
 )
-import pandas as pd
 
 
 def assert_datetime(datetime_string):
-    got = from_str_to_timedelta(datetime_string)
-    expected = pd.to_timedelta(datetime_string).to_pytimedelta()
-    assert got == expected
+    str_in_timedelta = from_str_to_timedelta(datetime_string)
+    got_string = str(str_in_timedelta)
+    expected_string = datetime_string
+    assert got_string == expected_string
 
 
 def test_simple_timedelta_with_8_hours():

--- a/tests/utils/test_timedelta_converter.py
+++ b/tests/utils/test_timedelta_converter.py
@@ -1,0 +1,68 @@
+import datetime
+from hrflow_connectors.utils.timedelta_converter import (
+    from_str_to_timedelta,
+    TimeDeltaFormatError,
+)
+import pandas as pd
+
+
+def assert_datetime(datetime_string):
+    got = from_str_to_timedelta(datetime_string)
+    expected = pd.to_timedelta(datetime_string).to_pytimedelta()
+    assert got == expected
+
+
+def test_simple_timedelta_with_8_hours():
+    assert_datetime("8:05:32")
+
+
+def test_simple_timedelta_with_23_hours():
+    assert_datetime("23:05:32")
+
+
+def test_simple_timedelta_with_days_hours():
+    assert_datetime("66 days, 8:05:56")
+
+
+def test_simple_neg_timedelta_with_days_hours():
+    assert_datetime("-66 days, 8:05:56")
+
+
+def test_simple_timedelta_with_days_hours_millisecond():
+    assert_datetime("-1803 days, 15:54:03.999990")
+
+
+def test_simple_neg_timedelta_with_days_hours_millisecond():
+    assert_datetime("-1804 days, 15:54:03.999990")
+
+
+def test_simple_neg_timedelta_with_one_day_hours_millisecond():
+    assert_datetime("-1 day, 15:54:03.999990")
+
+
+def test_wrong_timedelta_with_days_hours_millisecond_space_missing():
+    try:
+        assert_datetime("-1803days, 15:54:03.999990")
+    except TimeDeltaFormatError:
+        pass
+
+
+def test_wrong_timedelta_with_days_hours_millisecond_with_letter():
+    try:
+        assert_datetime("-HH days, 15:54:03.999990")
+    except TimeDeltaFormatError:
+        pass
+
+
+def test_wrong_timedelta_with_days_hours_millisecond_with_plus():
+    try:
+        assert_datetime("+01 days, 15:54:03.999990")
+    except TimeDeltaFormatError:
+        pass
+
+
+def test_wrong_timedelta_with_days_hours_without_seconds():
+    try:
+        assert_datetime("1 days, 15:54")
+    except TimeDeltaFormatError:
+        pass


### PR DESCRIPTION
This merge will :
* add `utils` :
  * timedelta converter
  * datetime converter
* add `XMLBoardAction` (like Samsic "get all jobs")
* add an option to call external format function `format_function_name`
* move `python_requires` to `[options]` in `setup.cfg`
* ignore `test/connectors` and config coverage
* replace `ROOT_PATH` by `pytestconfig.rootpath`