### PR TITLE
Feature: Greenhouse connector to pull jobs into HrFlow.ai boards

### DIFF
--- a/src/hrflow_connectors/connectors/boards/greenhouse/README.md
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/README.md
@@ -37,8 +37,7 @@ logger = get_logger_with_basic_config()
 client = Hrflow(api_secret="MY_X-API-KEY", api_user="MY_X-USER-EMAIL")
 
 action = GetAllJobs(
-
-    board_token="MY_board_token",
+    board_token="MY_BOARD_TOKEN",
     hrflow_client=client,
     board_key="MY_BOARD_KEY",
     hydrate_with_parsing=True,

--- a/src/hrflow_connectors/connectors/boards/greenhouse/README.md
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/README.md
@@ -18,7 +18,7 @@
 | `board_key` :red_circle: | `str` | Board key where the jobs to be added will be stored        |
 | `hydrate_with_parsing`  | `bool` | Enrich the job with parsing. Default value : `False`        |
 | `archive_deleted_jobs_from_stream`  | `bool` | Archive Board jobs when they are no longer in the incoming job stream. Default value : `True`        |
-| `board_token` :red_circle: | `str` |  Job Board data in `Greenhouse` is publicly available, so authentication is not required for any GET endpoints. `board_token` is the identifier of a given board on greenhouse, for example `lyft` for the `Lyft Company`, for testing use board_token = `vaulttec`     |
+| `board_token` :red_circle: | `str` |  Job Board data in `Greenhouse` is publicly available, so authentication is not required for any GET endpoints. `board_token` is the identifier of a given board on greenhouse, for example `lyft` for the `Lyft Company`, for testing use board_token = `vaulttec`. It is inserted in the url: "https://boards-api.greenhouse.io/v1/boards/{board_token}/jobs/?content=true"     |
 
 :red_circle: : *required* 
 

--- a/src/hrflow_connectors/connectors/boards/greenhouse/README.md
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/README.md
@@ -1,0 +1,47 @@
+# Greenhouse Connector
+**Greenhouse is an ATS.**
+
+`Greenhouse` :arrow_right: `Hrflow.ai`
+
+## GetAllJobs
+`GetAllJobs` gets all available jobs listed on ***Greenhouse board***. It adds all these **jobs** to a ***Hrflow.ai Board***.
+
+### Parameters
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `logics`  | `List[str]` | Function names to apply as filter before pushing the data. Default value : `[]`        |
+| `local_scope`  | `Optional[Dict[str, Any]]` | A dictionary containing the current scope's local variables. Default value : `None`        |
+| `global_scope`  | `Optional[Dict[str, Any]]` | A dictionary containing the current scope's global variables. Default value : `None`       |
+| `format_function_name`  | `Optional[str]` | Function name to format job before pushing. Default value : `None`        |
+| `hrflow_client` :red_circle: | `hrflow.Hrflow` | Hrflow client instance used to communicate with the Hrflow.ai API        |
+| `board_key` :red_circle: | `str` | Board key where the jobs to be added will be stored        |
+| `hydrate_with_parsing`  | `bool` | Enrich the job with parsing. Default value : `False`        |
+| `archive_deleted_jobs_from_stream`  | `bool` | Archive Board jobs when they are no longer in the incoming job stream. Default value : `True`        |
+| `board_token` :red_circle: | `str` |  Job Board data in `Greenhouse` is publicly available, so authentication is not required for any GET endpoints. `board_token` is the identifier of a given board on greenhouse, for example `lyft` for the `Lyft Company`, for testing use board_token = `vaulttec`     |
+
+:red_circle: : *required* 
+
+### Example
+
+```python
+from hrflow import Hrflow
+
+from hrflow_connectors.connectors.boards.Greenhouse import GetAllJobs
+from hrflow_connectors.utils.logger import get_logger_with_basic_config
+
+# We add a basic configuration to our logger to see the messages displayed in the standard output
+# This is not mandatory. It allows you to see what the connector is doing.
+logger = get_logger_with_basic_config()
+
+client = Hrflow(api_secret="MY_X-API-KEY", api_user="MY_X-USER-EMAIL")
+
+action = GetAllJobs(
+
+    board_token="MY_board_token",
+    hrflow_client=client,
+    board_key="MY_BOARD_KEY",
+    hydrate_with_parsing=True,
+)
+action.execute()
+```

--- a/src/hrflow_connectors/connectors/boards/greenhouse/__init__.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/__init__.py
@@ -1,0 +1,2 @@
+from .actions import *
+from .spec import *

--- a/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
@@ -56,15 +56,19 @@ class GetAllJobs(HTTPStream, BoardAction):
         """
 
         job = dict()
+        #name
         job["name"] = data.get("title")
+        #summary
         job["summary"] = None
+        #reference
         job["reference"] = str(data.get("internal_job_id"))
+        #url
         job["url"] = data.get("absolute_url")
+        #location
         location = data.get("location").get("name")
         job["location"] = dict(text=location, lat=None, lng=None)
-
+        #sections
         description_content = data.get("content")
-
         text = remove_html_tags(html.unescape(description_content))
 
         job["sections"] = [
@@ -74,8 +78,9 @@ class GetAllJobs(HTTPStream, BoardAction):
                 description=text,
             )
         ]
-        job["metadata"] = data.get("metadata")
-
+        #metadata
+        job["metadatas"] = data.get("metadata")
+        #tags
         department_name = data.get("departments")
         office_name = data.get("offices")
         education = data.get("education_optional")
@@ -87,7 +92,7 @@ class GetAllJobs(HTTPStream, BoardAction):
             dict(name="greenhouse_education", value=education),
             dict(name="greenhouse_employment", value=employment),
         ]
-
+        #updated_at
         job["updated_at"] = data.get("updated_at")
 
         return job

--- a/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
@@ -56,22 +56,22 @@ class GetAllJobs(HTTPStream, BoardAction):
         """
 
         job = dict()
-        #name
+        # name
         job["name"] = data.get("title")
-        #summary
+        # summary
         job["summary"] = None
-        #reference
+        # reference
         job["reference"] = str(data.get("internal_job_id"))
-        #url
+        # url
         job["url"] = data.get("absolute_url")
-        #location
+        # location
         location = data.get("location").get("name")
         job["location"] = dict(text=location, lat=None, lng=None)
-        #sections
+        # sections
         description_content = data.get("content")
-        #convert the escaped description content into html format
+        # convert the escaped description content into html format
         description_html = html.unescape(description_content)
-        #remove html tags to get clean text
+        # remove html tags to get clean text
         text = remove_html_tags(description_html)
 
         job["sections"] = [
@@ -81,9 +81,9 @@ class GetAllJobs(HTTPStream, BoardAction):
                 description=text,
             )
         ]
-        #metadata
+        # metadata
         job["metadatas"] = data.get("metadata")
-        #tags
+        # tags
         department_name = data.get("departments")
         office_name = data.get("offices")
         education = data.get("education_optional")
@@ -95,7 +95,7 @@ class GetAllJobs(HTTPStream, BoardAction):
             dict(name="greenhouse_education", value=education),
             dict(name="greenhouse_employment", value=employment),
         ]
-        #updated_at
+        # updated_at
         job["updated_at"] = data.get("updated_at")
 
         return job

--- a/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
@@ -1,0 +1,61 @@
+from typing import Iterator, Dict, Any
+from pydantic import Field
+
+from ....core.action import BoardAction
+from ....core.http import HTTPStream
+from ....core.auth import NoAuth
+from ....utils.logger import get_logger
+
+
+logger = get_logger()
+
+
+class GetAllJobs(HTTPStream, BoardAction):
+    auth: NoAuth
+    BOARD_TOKEN: str = Field(
+        ...,
+        description="Job Board URL token, mandatory to access job boards on `greenhouse.io`: `https://boards-api.greenhouse.io/v1/boards/{board_token}/jobs` getting jobs doesn't require an API Key",
+    )
+
+    @property
+    def base_url(self):
+        return "https://boards-api.greenhouse.io/v1/boards/{}/jobs".format(
+            self.BOARD_TOKEN
+        )
+
+    @property
+    def http_method(self):
+        return "GET"
+
+    def pull(self) -> Iterator[Dict[str, Any]]:
+
+        self.params["content"] = True
+        response = self.send_request()
+        if response.status_code == 200:
+            job_dict = response.json()
+            TOTAL_JOB = job_dict["meta"]["total"]
+            logger.info(f"total jobs found: {TOTAL_JOB}")
+            job_list = job_dict["jobs"]
+            return job_list
+        else:
+            logger.error(f"Failed to get jobs from board: {self.BOARD_TOKEN}")
+            error_message = "Unable to pull the data ! Reason : `{}`"
+            raise ConnectionError(error_message.format(response.content))
+
+    def format(self, data: Dict[str, Any]) -> Dict[str, Any]:
+
+        job = dict()
+
+        job["name"] = data.get("title")
+        job["reference"] = data.get("internal_job_id")
+        job["url"] = data.get("absolute_url")
+        location = data.get("location").get("name")
+        job["location"] = dict(text=location, lat=None, lng=None)
+        description = data.get("content")
+        job["sections"] = dict(
+            name="greenhouse_description",
+            title="greenhouse_description",
+            description=description,
+        )
+
+        return job

--- a/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
@@ -69,7 +69,10 @@ class GetAllJobs(HTTPStream, BoardAction):
         job["location"] = dict(text=location, lat=None, lng=None)
         #sections
         description_content = data.get("content")
-        text = remove_html_tags(html.unescape(description_content))
+        #convert the escaped description content into html format
+        description_html = html.unescape(description_content)
+        #remove html tags to get clean text
+        text = remove_html_tags(description_html)
 
         job["sections"] = [
             dict(

--- a/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
@@ -1,6 +1,6 @@
 from typing import Iterator, Dict, Any
 from pydantic import Field
-from html.parser import HTMLParser
+import html
 from ....core.action import BoardAction
 from ....core.http import HTTPStream
 from ....utils.logger import get_logger
@@ -12,7 +12,7 @@ logger = get_logger()
 class GetAllJobs(HTTPStream, BoardAction):
     board_token: str = Field(
         ...,
-        description="Job Board URL token, which is usually the company `name` -for example `lyft`- when it has job listings on greenhouse, mandatory to access job boards on `greenhouse.io`: `https://boards-api.greenhouse.io/v1/boards/{board_token}/jobs` getting jobs doesn't require an API Key",
+        description="Job Board URL token, which is usually the company `name` -for example `lyft`- when it has job listings on greenhouse, mandatory to access job boards on `greenhouse.io`: `https://boards-api.greenhouse.io/v1/boards/{board_token}/jobs`, getting jobs doesn't require an API Key",
     )
 
     @property
@@ -30,8 +30,6 @@ class GetAllJobs(HTTPStream, BoardAction):
     def pull(self) -> Iterator[Dict[str, Any]]:
         """pull : sends a request to get all jobs from a greenhouse job board
 
-        
-
         Returns:
             Iterator[Dict[str, Any]]: list of all jobs with their content if available
         """
@@ -39,13 +37,14 @@ class GetAllJobs(HTTPStream, BoardAction):
         response = self.send_request()
         if response.status_code == 200:
             job_dict = response.json()
-            total_info= job_dict["meta"]["total"]
+            total_info = job_dict["meta"]["total"]
             job_list = job_dict["jobs"]
             job_number = len(job_list)
             logger.info(f"{job_number} job(s) got. Total found : {total_info}")
             return job_list
         else:
             logger.error(f"Failed to get jobs from board: {self.board_token}")
+            logger.debug(f"Check that your board token: {self.board_token} is valid")
             error_message = "Unable to pull the data ! Reason : `{}`"
             raise ConnectionError(error_message.format(response.content))
 
@@ -65,14 +64,16 @@ class GetAllJobs(HTTPStream, BoardAction):
         job["location"] = dict(text=location, lat=None, lng=None)
 
         description_content = data.get("content")
-        parser = HTMLParser()
-        text = remove_html_tags(parser.unescape(description_content))
 
-        job["sections"] = [dict(
-            name="greenhouse_description",
-            title="greenhouse_description",
-            description=text,
-        )]
+        text = remove_html_tags(html.unescape(description_content))
+
+        job["sections"] = [
+            dict(
+                name="greenhouse_description",
+                title="greenhouse_description",
+                description=text,
+            )
+        ]
         job["metadata"] = data.get("metadata")
 
         department_name = data.get("departments")

--- a/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
@@ -51,7 +51,7 @@ class GetAllJobs(HTTPStream, BoardAction):
 
     def format(self, data: Dict[str, Any]) -> Dict[str, Any]:
         """
-        format : convert every job pulled from greenhouse job board into a HrFlow job object
+        format each job pulled from greenhouse job board into a HrFlow job object
 
         Returns:
             Dict[str, Any]: job in the HrFlow job object format

--- a/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
@@ -86,7 +86,7 @@ class GetAllJobs(HTTPStream, BoardAction):
         # tags
         department_name = data.get("departments")
         office_name = data.get("offices")
-        education = data.get("education_optional")
+        education = data.get("education")
         employment = data.get("employment")
 
         job["tags"] = [

--- a/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
@@ -61,7 +61,7 @@ class GetAllJobs(HTTPStream, BoardAction):
         # summary
         job["summary"] = None
         # reference
-        job["reference"] = str(data.get("internal_job_id"))
+        job["reference"] = str(data.get("id"))
         # url
         job["url"] = data.get("absolute_url")
         # location

--- a/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
@@ -28,7 +28,8 @@ class GetAllJobs(HTTPStream, BoardAction):
         return "GET"
 
     def pull(self) -> Iterator[Dict[str, Any]]:
-        """pull : sends a request to get all jobs from a greenhouse job board
+        """
+        pull all jobs from a greenhouse job board
 
         Returns:
             Iterator[Dict[str, Any]]: list of all jobs with their content if available
@@ -49,7 +50,8 @@ class GetAllJobs(HTTPStream, BoardAction):
             raise ConnectionError(error_message.format(response.content))
 
     def format(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        """format : convert every job pulled from greenhouse job board into a HrFlow job object
+        """
+        format : convert every job pulled from greenhouse job board into a HrFlow job object
 
         Returns:
             Dict[str, Any]: job in the HrFlow job object format

--- a/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/actions.py
@@ -1,26 +1,26 @@
 from typing import Iterator, Dict, Any
 from pydantic import Field
-
+from html.parser import HTMLParser
 from ....core.action import BoardAction
 from ....core.http import HTTPStream
-from ....core.auth import NoAuth
 from ....utils.logger import get_logger
-
+from ....utils.clean_text import remove_html_tags
 
 logger = get_logger()
 
 
 class GetAllJobs(HTTPStream, BoardAction):
-    auth: NoAuth
-    BOARD_TOKEN: str = Field(
+    board_token: str = Field(
         ...,
-        description="Job Board URL token, mandatory to access job boards on `greenhouse.io`: `https://boards-api.greenhouse.io/v1/boards/{board_token}/jobs` getting jobs doesn't require an API Key",
+        description="Job Board URL token, which is usually the company `name` -for example `lyft`- when it has job listings on greenhouse, mandatory to access job boards on `greenhouse.io`: `https://boards-api.greenhouse.io/v1/boards/{board_token}/jobs` getting jobs doesn't require an API Key",
     )
 
     @property
     def base_url(self):
-        return "https://boards-api.greenhouse.io/v1/boards/{}/jobs".format(
-            self.BOARD_TOKEN
+        return (
+            "https://boards-api.greenhouse.io/v1/boards/{}/jobs/?content=true".format(
+                self.board_token
+            )
         )
 
     @property
@@ -28,34 +28,65 @@ class GetAllJobs(HTTPStream, BoardAction):
         return "GET"
 
     def pull(self) -> Iterator[Dict[str, Any]]:
+        """pull : sends a request to get all jobs from a greenhouse job board
 
-        self.params["content"] = True
+        
+
+        Returns:
+            Iterator[Dict[str, Any]]: list of all jobs with their content if available
+        """
+
         response = self.send_request()
         if response.status_code == 200:
             job_dict = response.json()
-            TOTAL_JOB = job_dict["meta"]["total"]
-            logger.info(f"total jobs found: {TOTAL_JOB}")
+            total_info= job_dict["meta"]["total"]
             job_list = job_dict["jobs"]
+            job_number = len(job_list)
+            logger.info(f"{job_number} job(s) got. Total found : {total_info}")
             return job_list
         else:
-            logger.error(f"Failed to get jobs from board: {self.BOARD_TOKEN}")
+            logger.error(f"Failed to get jobs from board: {self.board_token}")
             error_message = "Unable to pull the data ! Reason : `{}`"
             raise ConnectionError(error_message.format(response.content))
 
     def format(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        """format : convert every job pulled from greenhouse job board into a HrFlow job object
+
+        Returns:
+            Dict[str, Any]: job in the HrFlow job object format
+        """
 
         job = dict()
-
         job["name"] = data.get("title")
-        job["reference"] = data.get("internal_job_id")
+        job["summary"] = None
+        job["reference"] = str(data.get("internal_job_id"))
         job["url"] = data.get("absolute_url")
         location = data.get("location").get("name")
         job["location"] = dict(text=location, lat=None, lng=None)
-        description = data.get("content")
-        job["sections"] = dict(
+
+        description_content = data.get("content")
+        parser = HTMLParser()
+        text = remove_html_tags(parser.unescape(description_content))
+
+        job["sections"] = [dict(
             name="greenhouse_description",
             title="greenhouse_description",
-            description=description,
-        )
+            description=text,
+        )]
+        job["metadata"] = data.get("metadata")
+
+        department_name = data.get("departments")
+        office_name = data.get("offices")
+        education = data.get("education_optional")
+        employment = data.get("employment")
+
+        job["tags"] = [
+            dict(name="greenhouse_department", value=department_name),
+            dict(name="greenhouse_office", value=office_name),
+            dict(name="greenhouse_education", value=education),
+            dict(name="greenhouse_employment", value=employment),
+        ]
+
+        job["updated_at"] = data.get("updated_at")
 
         return job

--- a/src/hrflow_connectors/connectors/boards/greenhouse/spec.py
+++ b/src/hrflow_connectors/connectors/boards/greenhouse/spec.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+from typing import Tuple
+
+from .actions import GetAllJobs
+
+
+class Spec(BaseModel):
+    actions: Tuple[GetAllJobs]

--- a/tests/connectors/boards/greenhouse/test_get_all_jobs/test_get_all_jobs.py
+++ b/tests/connectors/boards/greenhouse/test_get_all_jobs/test_get_all_jobs.py
@@ -1,4 +1,3 @@
-
 from hrflow_connectors.connectors.boards.greenhouse import GetAllJobs
 
 

--- a/tests/connectors/boards/greenhouse/test_get_all_jobs/test_get_all_jobs.py
+++ b/tests/connectors/boards/greenhouse/test_get_all_jobs/test_get_all_jobs.py
@@ -1,0 +1,12 @@
+
+from hrflow_connectors.connectors.boards.greenhouse import GetAllJobs
+
+
+def test_GetAllJobs(logger, hrflow_client):
+    action = GetAllJobs(
+        board_token='lyft',
+        hrflow_client=hrflow_client("dev-demo"),
+        board_key="fc48d01539cde9e8a8ca17238a61c16826837729",
+        hydrate_with_parsing=True,
+    )
+    action.execute()

--- a/tests/connectors/boards/greenhouse/test_get_all_jobs/test_get_all_jobs.py
+++ b/tests/connectors/boards/greenhouse/test_get_all_jobs/test_get_all_jobs.py
@@ -4,7 +4,7 @@ from hrflow_connectors.connectors.boards.greenhouse import GetAllJobs
 
 def test_GetAllJobs(logger, hrflow_client):
     action = GetAllJobs(
-        board_token='lyft',
+        board_token='vaulttec',
         hrflow_client=hrflow_client("dev-demo"),
         board_key="fc48d01539cde9e8a8ca17238a61c16826837729",
         hydrate_with_parsing=True,


### PR DESCRIPTION
This merge request will add in the hrflow_connectors boards a new connector for Greenhouse job postings:

actions.py which containts the base scripts to run and send a request to greenhouse job boards API to pull their job postings

The file contains the `GetAllJobs` class, which inherits the `BoardAction` class and the `HTTPStream` class, divided into the main functions `pull` that pull jobs data and `format` which formats pulled jobs into HrFlow job object format.

--It will also add inside the tests folder, a file test_get_all_jobs.py to test the connector.