### PR TITLE
Test: Migrate board_keys in pull_jobs tests to dev-demo

### DIFF
--- a/src/hrflow_connectors/connectors/breezyhr/actions.py
+++ b/src/hrflow_connectors/connectors/breezyhr/actions.py
@@ -133,7 +133,6 @@ class PullJobsAction(PullJobsBaseAction):
         job["created_at"] = data.get("creation_date")
         job["updated_at"] = data.get("updated_date")
 
-        job["metadatas"] = data.get("tags")
         return job
 
 

--- a/tests/connectors/breezyhr/test_pull_jobs.py
+++ b/tests/connectors/breezyhr/test_pull_jobs.py
@@ -18,7 +18,7 @@ def test_PullJobsAction(logger, auth, hrflow_client):
     Breezyhr.pull_jobs(
         auth=auth,
         hrflow_client=hrflow_client("dev-demo"),
-        board_key="fa06643e19d811e8da472858c07f8bbbd954dfd0",
+        board_key="194d9440437c157275f33ec9eda80a0250872e54",
         hydrate_with_parsing=True,
         company_name="Hrflow.ai"
     )

--- a/tests/connectors/ceridian/test_pull_jobs.py
+++ b/tests/connectors/ceridian/test_pull_jobs.py
@@ -6,6 +6,6 @@ def test_PullJobs(logger, hrflow_client):
         subdomain='ustest61-services',
         client_name_space = 'ddn',
         hrflow_client=hrflow_client("dev-demo"),
-        board_key="f54e75c62da8f3273789e10a3c89d9877b72c66d",
+        board_key="3bc89d440036641fedb04349e8e9767d77fa6830",
         hydrate_with_parsing=True,
     )

--- a/tests/connectors/crosstalent/test_pull_jobs.py
+++ b/tests/connectors/crosstalent/test_pull_jobs.py
@@ -23,6 +23,6 @@ def test_PullJobsAction(logger, auth, hrflow_client):
         auth=auth,
         subdomain="vulcain-eng--recette.my",
         hrflow_client=hrflow_client("dev-demo"),
-        board_key="8eba188e1af123a9818d00974ff37b943b7d54f4",
+        board_key="34ba5e086fd953f2bb835c58f2a3bb2425dc09e6",
         hydrate_with_parsing=True,
     )

--- a/tests/connectors/greenhouse/test_pull_jobs.py
+++ b/tests/connectors/greenhouse/test_pull_jobs.py
@@ -5,6 +5,6 @@ def test_PullJobsAcrion(logger, hrflow_client):
     Greenhouse.pull_jobs(
         board_token="vaulttec",
         hrflow_client=hrflow_client("dev-demo"),
-        board_key="61abdf5e11a8b75f2f5d1789339ee3638d4c6197",
+        board_key="f02c4d041ce04a4657e7aaa360fdeb3712aec130",
         hydrate_with_parsing=True,
     )

--- a/tests/connectors/recruitee/test_pull_jobs.py
+++ b/tests/connectors/recruitee/test_pull_jobs.py
@@ -5,6 +5,6 @@ def test_PullJobs(logger, hrflow_client):
     Recruitee.pull_jobs(
         subdomain='testhr',
         hrflow_client=hrflow_client("dev-demo"),
-        board_key="c430a1fe111a4076605a8dee85448300bd40f890",
+        board_key="243ed7c3fef55e1bacee3ba71b6d589e2b21079a",
         hydrate_with_parsing=True,
     )

--- a/tests/connectors/sapsuccessfactors/test_pull_jobs.py
+++ b/tests/connectors/sapsuccessfactors/test_pull_jobs.py
@@ -17,6 +17,6 @@ def test_PullJobs(logger,auth, hrflow_client):
         api_server="sandbox.api.sap.com:443/successfactors",
         top=20,
         hrflow_client=hrflow_client("dev-demo"),
-        board_key="193bc9ff5d3076937d93950381783e108c957fb3",
+        board_key="91c42ec77a7abfdd51e2a48a4a4d7ab147e0f17d",
         hydrate_with_parsing=True,
     )

--- a/tests/connectors/smartrecruiters/test_pull_jobs.py
+++ b/tests/connectors/smartrecruiters/test_pull_jobs.py
@@ -17,7 +17,7 @@ def test_PullJobsAction(logger, auth, hrflow_client):
         auth=auth,
         hrflow_client=hrflow_client("dev-demo"),
         limit=2,
-        board_key="8ebdea98768dfc04d15f76afab70415ed280ea90",
+        board_key="1bed06c0123081959f830a920b3113d2540a02f7",
         hydrate_with_parsing=False,
         archive_deleted_jobs_from_stream=False,
         posting_status="PUBLIC",

--- a/tests/connectors/taleez/test_pull_jobs.py
+++ b/tests/connectors/taleez/test_pull_jobs.py
@@ -17,6 +17,6 @@ def test_PullJobsAction(logger, auth, hrflow_client):
     Taleez.pull_jobs(
         auth=auth,
         hrflow_client=hrflow_client("dev-demo"),
-        board_key="234e96cf22440fa88cae5bca854d674f77fa8f93",
+        board_key="a820ecb28fc23b8217276cf2352387feaa5d7249",
         hydrate_with_parsing=True,
     )

--- a/tests/connectors/workable/test_pull_jobs.py
+++ b/tests/connectors/workable/test_pull_jobs.py
@@ -5,6 +5,6 @@ def test_PullJobsAcrion(logger, hrflow_client):
     Workable.pull_jobs(
         subdomain="eurostar",
         hrflow_client=hrflow_client("dev-demo"),
-        board_key="12dc2abb0d952bfcbbc6259b76c0631754459787",
+        board_key="0d9a50e90e529e43394cf84b2f0666432551980b",
         hydrate_with_parsing=True,
     )


### PR DESCRIPTION
The tests passed for all connectors and actions.
There was a bug in Breezyhr job["metadatas"] that caused an indexing error , it was corrected