### PR TITLE
Refacto: Change `credentials` to Config class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ MANIFEST
 # Per-project virtualenvs
 .venv*/
 .conda*/
+.env
 
 # Credentials
 credentials

--- a/poetry.lock
+++ b/poetry.lock
@@ -795,6 +795,17 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 six = ">=1.5"
 
 [[package]]
+name = "python-dotenv"
+version = "0.19.2"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+cli = ["click (>=5.0)"]
+
+[[package]]
 name = "python-magic"
 version = "0.4.24"
 description = "File type identification using libmagic"
@@ -1069,7 +1080,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "e356606c4d37d4db0a27b1f616246c4852f185d882175210591b392a4c15dfda"
+content-hash = "6558d66d9f376bd3468b47f501a33ae1b835aaa2c4b6d18f46bea9bc009a04ef"
 
 [metadata.files]
 appdirs = [
@@ -1516,6 +1527,10 @@ pytest-cov = [
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+python-dotenv = [
+    {file = "python-dotenv-0.19.2.tar.gz", hash = "sha256:a5de49a31e953b45ff2d2fd434bbc2670e8db5273606c1e737cc6b93eff3655f"},
+    {file = "python_dotenv-0.19.2-py2.py3-none-any.whl", hash = "sha256:32b2bdc1873fd3a3c346da1c6db83d0053c3c62f28f1f38516070c4c8971b1d3"},
 ]
 python-magic = [
     {file = "python-magic-0.4.24.tar.gz", hash = "sha256:de800df9fb50f8ec5974761054a708af6e4246b03b4bdaee993f948947b0ebcf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ pytest-cov = "^3.0.0"
 black = "20.8b0"
 unittest = "^0.0"
 responses = "^0.16.0"
+python-dotenv = "^0.19.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/hrflow_connectors/utils/config.py
+++ b/src/hrflow_connectors/utils/config.py
@@ -1,0 +1,62 @@
+import os
+from dotenv import load_dotenv
+
+from .logger import get_logger
+
+logger = get_logger()
+
+
+class ConfigError(Exception):
+    """
+    Config Error
+    """
+
+    pass
+
+
+class Config:
+    """
+    Config class
+
+    Add the configuration line in `.env` to the root of the project.
+    You must start the environment variable name with `HRFLOW_CONNECTORS`.
+    For example: `HRFLOW_CONNECTORS_COMPANY_TOKEN = "abc"`.
+
+    Instantiate `Config` and call the newly created attribute (without `HRFLOW_CONNECTORS_` prefix).
+    If the environment variable is not found, then it will raise a `ConfigError`.
+
+    >>> config = Config()
+    >>> config.COMPANY_TOKEN
+    'abc'
+    >>> config.OTHER_TOKEN
+    ConfigError: Unable to get the value of the `OTHER_TOKEN` field from the configuration. Check that the field `HRFLOW_CONNECTORS_OTHER_TOKEN` is initialized in `.env` at the root of the project.
+    """
+
+    def __init__(self):
+        load_dotenv()
+        for key, value in os.environ.items():
+            if key.startswith("HRFLOW_CONNECTORS_"):
+                prefix_last_char_position = len("HRFLOW_CONNECTORS_")
+                # truncate var name to remove `HRFLOW_CONNECTORS_`
+                attribute_name = key[prefix_last_char_position:]
+                self.__setattr__(attribute_name, value)
+
+    def __getattr__(self, name: str):
+        """
+        Default behavior if the attribute `name` is not found.
+
+        Python call `__getattribute__` and if the attribute is not found
+        Then Python call `__getattr__`.
+
+        Args:
+            name (str): Attribute name
+
+        Raises:
+            ConfigError: If the attribute with the `name` is not found
+        """
+        error_message = (
+            f"Unable to get the value of the `{name}` field from the configuration. "
+        )
+        error_message += f"Check that the `HRFLOW_CONNECTORS_{name}` field is initialized in `.env` at the root of the project."
+        logger.error(error_message)
+        raise ConfigError(error_message)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from typing import Dict, Any, Callable
 from hrflow import Hrflow
 
 from hrflow_connectors.utils.logger import get_logger_with_basic_config
+from hrflow_connectors.utils.config import Config
 
 
 @pytest.fixture(scope="session")
@@ -25,6 +26,17 @@ def credentials(pytestconfig) -> Dict[str, Any]:
     with open(os.path.join(pytestconfig.rootpath, "credentials.json"), "r") as f:
         credentials = json.loads(f.read())
     return credentials
+
+
+@pytest.fixture(scope="session")
+def config() -> Config:
+    """
+    Get config from the `.env` file at the root of the project (to be defined)
+
+    Returns:
+        Config: Config instance
+    """
+    return Config()
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,19 +16,6 @@ from hrflow_connectors.utils.config import Config
 
 
 @pytest.fixture(scope="session")
-def credentials(pytestconfig) -> Dict[str, Any]:
-    """
-    Get credentials from a file in the root of the project `credentials.json` (to be defined)
-
-    Returns:
-        Dict[str, Any]: Credentials
-    """
-    with open(os.path.join(pytestconfig.rootpath, "credentials.json"), "r") as f:
-        credentials = json.loads(f.read())
-    return credentials
-
-
-@pytest.fixture(scope="session")
 def config() -> Config:
     """
     Get config from the `.env` file at the root of the project (to be defined)
@@ -40,7 +27,7 @@ def config() -> Config:
 
 
 @pytest.fixture(scope="session")
-def hrflow_client(credentials) -> Callable:
+def hrflow_client(config) -> Callable:
     """
     Get a function to generate an instance of Hrflow Client
 
@@ -53,10 +40,15 @@ def hrflow_client(credentials) -> Callable:
     """
 
     def hrflow_client_func(portal_name="dev-demo"):
-        x_api_key = credentials["hrflow"][portal_name]["x-api-key"]
-        x_user_email = credentials["hrflow"][portal_name]["x-user-email"]
-        client = Hrflow(api_secret=x_api_key, api_user=x_user_email)
-        return client
+        if portal_name == "dev-demo":
+            x_api_key = config.HRFLOW_DEVDEMO_XAPIKEY
+            x_user_email = config.HRFLOW_DEVDEMO_XUSEREMAIL
+        elif portal_name == "vulcain":
+            x_api_key = config.HRFLOW_VULCAIN_XAPIKEY
+            x_user_email = config.HRFLOW_VULCAIN_XUSEREMAIL
+        else:
+            raise RuntimeError(f"Hrflow Portal `{portal_name}` not found !")
+        return Hrflow(api_secret=x_api_key, api_user=x_user_email)
 
     return hrflow_client_func
 

--- a/tests/connectors/breezyhr/test_pull_jobs.py
+++ b/tests/connectors/breezyhr/test_pull_jobs.py
@@ -5,11 +5,11 @@ from hrflow_connectors import Breezyhr
 
 
 @pytest.fixture
-def auth(credentials):
+def auth(config):
     auth = OAuth2EmailPasswordBody(
-        access_token_url = "https://api.breezy.hr/v3/signin",
-        email = credentials["breezyhr"]["email"],
-        password= credentials["breezyhr"]["password"]
+        access_token_url="https://api.breezy.hr/v3/signin",
+        email=config.BREEZYHR_EMAIL,
+        password=config.BREEZYHR_PASSWORD,
     )
     return auth
 
@@ -20,5 +20,5 @@ def test_PullJobsAction(logger, auth, hrflow_client):
         hrflow_client=hrflow_client("dev-demo"),
         board_key="fa06643e19d811e8da472858c07f8bbbd954dfd0",
         hydrate_with_parsing=True,
-        company_name="Hrflow.ai"
+        company_name="Hrflow.ai",
     )

--- a/tests/connectors/breezyhr/test_push_profile.py
+++ b/tests/connectors/breezyhr/test_push_profile.py
@@ -6,11 +6,11 @@ from hrflow_connectors.utils.hrflow import Profile, Source
 
 
 @pytest.fixture
-def auth(credentials):
+def auth(config):
     auth = OAuth2EmailPasswordBody(
         access_token_url="https://api.breezy.hr/v3/signin",
-        email=credentials["breezyhr"]["email"],
-        password=credentials["breezyhr"]["password"],
+        email=config.BREEZYHR_EMAIL,
+        password=config.BREEZYHR_PASSWORD,
     )
     return auth
 

--- a/tests/connectors/bullhorn/test_push_profile.py
+++ b/tests/connectors/bullhorn/test_push_profile.py
@@ -6,14 +6,14 @@ from hrflow_connectors.utils.hrflow import Profile, Source
 
 
 @pytest.fixture
-def auth(credentials):
+def auth(config):
     auth = OAuth2Session(auth_code_url="https://auth.bullhornstaffing.com/oauth/authorize",
                          access_token_url="https://auth.bullhornstaffing.com/oauth/token",
                          session_token_url="https://rest.bullhornstaffing.com/rest-services/login",
-                         client_id=credentials["bullhorn"]["client_id"],
-                         client_secret=credentials["bullhorn"]["client_secret"],
-                         username=credentials["bullhorn"]["username"],
-                         password=credentials["bullhorn"]["password"],
+                         client_id=config.BULLHORN_CLIENT_ID,
+                         client_secret=config.BULLHORN_CLIENT_SECRET,
+                         username=config.BULLHORN_USERNAME,
+                         password=config.BULLHORN_PASSWORD,
                          name="BhRestToken")
     return auth
 

--- a/tests/connectors/crosstalent/test_auth.py
+++ b/tests/connectors/crosstalent/test_auth.py
@@ -4,15 +4,14 @@ from hrflow_connectors import OAuth2PasswordCredentialsBody
 
 
 @pytest.fixture
-def auth(credentials):
+def auth(config):
     access_token_url = "https://test.salesforce.com/services/oauth2/token"
-
     auth = OAuth2PasswordCredentialsBody(
         access_token_url=access_token_url,
-        client_id=credentials["crosstalent"]["oauth2"]["client_id"],
-        client_secret=credentials["crosstalent"]["oauth2"]["client_secret"],
-        username=credentials["crosstalent"]["oauth2"]["username"],
-        password=credentials["crosstalent"]["oauth2"]["password"],
+        client_id=config.CROSSTALENT_CLIENT_ID,
+        client_secret=config.CROSSTALENT_CLIENT_SECRET,
+        username=config.CROSSTALENT_USERNAME,
+        password=config.CROSSTALENT_PASSWORD,
     )
     return auth
 

--- a/tests/connectors/crosstalent/test_pull_jobs.py
+++ b/tests/connectors/crosstalent/test_pull_jobs.py
@@ -5,15 +5,14 @@ from hrflow_connectors import Crosstalent
 
 
 @pytest.fixture
-def auth(credentials):
+def auth(config):
     access_token_url = "https://test.salesforce.com/services/oauth2/token"
-
     auth = OAuth2PasswordCredentialsBody(
         access_token_url=access_token_url,
-        client_id=credentials["crosstalent"]["oauth2"]["client_id"],
-        client_secret=credentials["crosstalent"]["oauth2"]["client_secret"],
-        username=credentials["crosstalent"]["oauth2"]["username"],
-        password=credentials["crosstalent"]["oauth2"]["password"],
+        client_id=config.CROSSTALENT_CLIENT_ID,
+        client_secret=config.CROSSTALENT_CLIENT_SECRET,
+        username=config.CROSSTALENT_USERNAME,
+        password=config.CROSSTALENT_PASSWORD,
     )
     return auth
 

--- a/tests/connectors/crosstalent/test_push_profile.py
+++ b/tests/connectors/crosstalent/test_push_profile.py
@@ -6,14 +6,14 @@ from hrflow_connectors.utils.hrflow import Profile, Source
 
 
 @pytest.fixture
-def auth(credentials):
+def auth(config):
     access_token_url = "https://test.salesforce.com/services/oauth2/token"
     auth = OAuth2PasswordCredentialsBody(
         access_token_url=access_token_url,
-        client_id=credentials["crosstalent"]["oauth2"]["client_id"],
-        client_secret=credentials["crosstalent"]["oauth2"]["client_secret"],
-        username=credentials["crosstalent"]["oauth2"]["username"],
-        password=credentials["crosstalent"]["oauth2"]["password"],
+        client_id=config.CROSSTALENT_CLIENT_ID,
+        client_secret=config.CROSSTALENT_CLIENT_SECRET,
+        username=config.CROSSTALENT_USERNAME,
+        password=config.CROSSTALENT_PASSWORD,
     )
     return auth
 

--- a/tests/connectors/flatchr/test_push_profile.py
+++ b/tests/connectors/flatchr/test_push_profile.py
@@ -6,9 +6,8 @@ from hrflow_connectors.utils.hrflow import Profile, Source
 
 
 @pytest.fixture
-def auth(credentials):
-    auth = AuthorizationAuth(value=credentials["flatchr"]["x-api-key"])
-    return auth
+def auth(config):
+    return AuthorizationAuth(value=config.FLATCHR_TOKEN)
 
 
 def test_PushProfileBaseAction(logger, auth, hrflow_client):

--- a/tests/connectors/greenhouse/test_push_profile.py
+++ b/tests/connectors/greenhouse/test_push_profile.py
@@ -5,16 +5,9 @@ from hrflow_connectors.core.auth import AuthorizationAuth, OAuth2PasswordCredent
 from hrflow_connectors.utils.hrflow import Profile, Source
 
 
-
-
 @pytest.fixture
-def auth(credentials):
-    auth = AuthorizationAuth(
-        name = 'Authorization',
-        value= credentials["greenhouse"]["oauth2"]["Authorization"]
-    )
-    
-    return auth
+def auth(config):
+    return AuthorizationAuth(value=config.GREENHOUSE_TOKEN)
 
 
 def test_PushProfile(logger, auth, hrflow_client):
@@ -24,8 +17,8 @@ def test_PushProfile(logger, auth, hrflow_client):
         source=Source(key="762d2f25b855f7cfd13e5585ef727d8fb6e752cb"),
     )
     response = Greenhouse.push_profile(
-        job_id = ["4179714004"] ,
-        on_behalf_of = "4249018004",
+        job_id=["4179714004"],
+        on_behalf_of="4249018004",
         auth=auth,
         hrflow_client=hrflow_client(),
         profile=profile,

--- a/tests/connectors/monster/test_catch_profile.py
+++ b/tests/connectors/monster/test_catch_profile.py
@@ -8,10 +8,10 @@ from typing import Dict, Any
 @pytest.fixture()
 def monster_request() -> Dict[str, Any]:
     """
-    Get credentials from a file in the root of the project `credentials.json` (to be defined)
+    Get monster request
 
     Returns:
-        Dict[str, Any]: Credentials
+        Dict[str, Any]: Monster request
     """
 
     url = (

--- a/tests/connectors/monster/test_push_job.py
+++ b/tests/connectors/monster/test_push_job.py
@@ -6,10 +6,10 @@ from hrflow_connectors.utils.hrflow import Job, Board
 
 
 @pytest.fixture
-def auth(credentials):
+def auth(config):
     auth = MonsterBodyAuth(
-        username=credentials["monster"]["username"],
-        password=credentials["monster"]["password"],
+        username=config.MONSTER_USERNAME,
+        password=config.MONSTER_PASSWORD,
     )
     return auth
 

--- a/tests/connectors/recruitee/test_push_profile.py
+++ b/tests/connectors/recruitee/test_push_profile.py
@@ -4,14 +4,10 @@ from hrflow_connectors import AuthorizationAuth
 from hrflow_connectors import Recruitee
 from hrflow_connectors.utils.hrflow import Profile, Source
 
+
 @pytest.fixture
-def auth(credentials):
-    auth = AuthorizationAuth(
-        name = 'Authorization',
-        value= credentials["recruitee"]["oauth2"]["Bearer"]
-    )
-    
-    return auth
+def auth(config):
+    return AuthorizationAuth(value=config.RECRUITEE_TOKEN)
 
 
 def test_PushProfile(logger, auth, hrflow_client):
@@ -21,8 +17,8 @@ def test_PushProfile(logger, auth, hrflow_client):
         source=Source(key="762d2f25b855f7cfd13e5585ef727d8fb6e752cb"),
     )
     response = Recruitee.push_profile(
-        company_id = "hrflowai",
-        offer_id = None,
+        company_id="hrflowai",
+        offer_id=None,
         auth=auth,
         hrflow_client=hrflow_client(),
         profile=profile,

--- a/tests/connectors/sapsuccessfactors/test_pull_jobs.py
+++ b/tests/connectors/sapsuccessfactors/test_pull_jobs.py
@@ -4,10 +4,10 @@ from hrflow_connectors import XAPIKeyAuth
 
 
 @pytest.fixture
-def auth(credentials):
+def auth(config):
     auth = XAPIKeyAuth(
         name='APIKey',
-        value=credentials["sapsuccessfactors"]["oauth2"]["APIKey"],
+        value=config.SAPSUCCESSFACTORS_TOKEN,
     )
     return auth
 

--- a/tests/connectors/sapsuccessfactors/test_push_profile.py
+++ b/tests/connectors/sapsuccessfactors/test_push_profile.py
@@ -6,12 +6,13 @@ from hrflow_connectors.utils.hrflow import Profile, Source
 
 
 @pytest.fixture
-def auth(credentials):
+def auth(config):
     auth = XAPIKeyAuth(
         name='APIKey',
-        value=credentials["sapsuccessfactors"]["oauth2"]["APIKey"],
+        value=config.SAPSUCCESSFACTORS_TOKEN,
     )
     return auth
+
 
 def test_PushProfile(logger,auth, hrflow_client):
 

--- a/tests/connectors/smartrecruiters/test_pull_jobs.py
+++ b/tests/connectors/smartrecruiters/test_pull_jobs.py
@@ -5,11 +5,8 @@ from hrflow_connectors import SmartRecruiters
 
 
 @pytest.fixture
-def auth(credentials):
-    auth = XSmartTokenAuth(
-        value=credentials["smartrecruiters"]["oauth2"]["X-SmartToken"]
-    )
-    return auth
+def auth(config):
+    return XSmartTokenAuth(value=config.SMARTRECRUITERS_TOKEN)
 
 
 def test_PullJobsAction(logger, auth, hrflow_client):

--- a/tests/connectors/smartrecruiters/test_push_profile.py
+++ b/tests/connectors/smartrecruiters/test_push_profile.py
@@ -6,11 +6,8 @@ from hrflow_connectors.utils.hrflow import Profile, Source
 
 
 @pytest.fixture
-def auth(credentials):
-    auth = XSmartTokenAuth(
-        value=credentials["smartrecruiters"]["oauth2"]["X-SmartToken"]
-    )
-    return auth
+def auth(config):
+    return XSmartTokenAuth(value=config.SMARTRECRUITERS_TOKEN)
 
 
 def test_SmartRecruitersPushProfileAction(logger, auth, hrflow_client):

--- a/tests/connectors/taleez/test_pull_jobs.py
+++ b/tests/connectors/taleez/test_pull_jobs.py
@@ -5,12 +5,8 @@ from hrflow_connectors import Taleez
 
 
 @pytest.fixture
-def auth(credentials):
-    auth = XTaleezAuth(
-        name = 'X-taleez-api-secret',
-        value=credentials["taleez"]["X-taleez-api-secret"]
-    )
-    return auth
+def auth(config):
+    return XTaleezAuth(value=config.TALEEZ_TOKEN)
 
 
 def test_PullJobsAction(logger, auth, hrflow_client):

--- a/tests/connectors/taleez/test_push_profile.py
+++ b/tests/connectors/taleez/test_push_profile.py
@@ -4,14 +4,10 @@ from hrflow_connectors import XTaleezAuth
 from hrflow_connectors import Taleez
 from hrflow_connectors.utils.hrflow import Profile, Source
 
-@pytest.fixture
-def auth(credentials):
-    auth = XTaleezAuth(
-        name = 'X-taleez-api-secret',
-        value=credentials["taleez"]["X-taleez-api-secret"]
-    )
-    return auth
 
+@pytest.fixture
+def auth(config):
+    return XTaleezAuth(value=config.TALEEZ_TOKEN)
 
 
 def test_PushProfile(logger, auth, hrflow_client):
@@ -21,9 +17,9 @@ def test_PushProfile(logger, auth, hrflow_client):
         source=Source(key="762d2f25b855f7cfd13e5585ef727d8fb6e752cb"),
     )
     response = Taleez.push_profile(
-        job_id = None,
+        job_id=None,
         auth=auth,
-        recruiter_id = 15886,
+        recruiter_id=15886,
         hrflow_client=hrflow_client(),
         profile=profile,
     )

--- a/tests/connectors/teamtailor/test_pull_jobs.py
+++ b/tests/connectors/teamtailor/test_pull_jobs.py
@@ -5,11 +5,8 @@ from hrflow_connectors import Teamtailor
 
 
 @pytest.fixture
-def auth(credentials):
-    auth = AuthorizationAuth(
-        value=credentials["teamtailor"]["Authorization"]
-    )
-    return auth
+def auth(config):
+    return AuthorizationAuth(value=config.TEAMTAILOR_TOKEN)
 
 
 def test_PullJobsAction(logger, auth, hrflow_client):

--- a/tests/connectors/teamtailor/test_push_profile.py
+++ b/tests/connectors/teamtailor/test_push_profile.py
@@ -4,14 +4,10 @@ from hrflow_connectors import AuthorizationAuth
 from hrflow_connectors import Teamtailor
 from hrflow_connectors.utils.hrflow import Profile, Source
 
+
 @pytest.fixture
-def auth(credentials):
-    auth = AuthorizationAuth(
-        name = 'Authorization',
-        value= credentials["teamtailor"]["Authorization"]
-    )
-    
-    return auth
+def auth(config):
+    return AuthorizationAuth(value=config.TEAMTAILOR_TOKEN)
 
 
 def test_PushProfile(logger, auth, hrflow_client):
@@ -21,7 +17,7 @@ def test_PushProfile(logger, auth, hrflow_client):
         source=Source(key="762d2f25b855f7cfd13e5585ef727d8fb6e752cb"),
     )
     response = Teamtailor.push_profile(
-        company_id = "hrflowai",
+        company_id="hrflowai",
         auth=auth,
         hrflow_client=hrflow_client("dev-demo"),
         profile=profile,

--- a/tests/utils/test_adress_to_lat_long.py
+++ b/tests/utils/test_adress_to_lat_long.py
@@ -52,7 +52,7 @@ def test_cities_code_lat_long_mapping():
 
 
 @responses.activate
-def test_get_lat_lng(credentials):
+def test_get_lat_lng():
 
     request_url = "https://geocode.search.hereapi.com/v1/geocode"
     body = {
@@ -99,13 +99,13 @@ def test_get_lat_lng(credentials):
                     cities_codes_dict,
                     cities_names_dict,
                     departments_codes_dict,
-                    credentials["here"]["HERE_API_KEY"]
+                    api_key="abc_here_key"
                 )
         assert name == expected
 
 
 @responses.activate
-def test_get_lat_lng_not_found_by_here(credentials):
+def test_get_lat_lng_not_found_by_here():
 
     cities_codes_dict = get_cities_code_lat_long_mapping()
 
@@ -125,13 +125,13 @@ def test_get_lat_lng_not_found_by_here(credentials):
         cities_codes_dict,
         cities_names_dict,
         departments_codes_dict,
-        credentials["here"]["HERE_API_KEY"]
+        api_key="abc_here_key"
     )
     assert name is None
 
 
 @responses.activate
-def test_get_lat_lng_not_api_key_here(credentials):
+def test_get_lat_lng_not_api_key_here():
 
     cities_codes_dict = get_cities_code_lat_long_mapping()
 

--- a/tests/utils/test_config.py
+++ b/tests/utils/test_config.py
@@ -1,0 +1,68 @@
+import os
+from hrflow_connectors.utils.config import ConfigError
+
+def test_Config_same_var_in_env_file(pytestconfig, config):
+    # Read `.env` file
+    env_path = os.path.join(pytestconfig.rootpath, ".env")
+    with open(env_path, "r") as env_file:
+        env_line_list = env_file.readlines()
+
+    def is_hrflow_connectors_var(line):
+        return line.startswith("HRFLOW_CONNECTORS_")
+
+    def clean_line(line):
+        return line.strip()
+
+    def remove_prefix(line):
+        prefix_last_char_position = len("HRFLOW_CONNECTORS_")
+        equal_char_position = line.index("=")
+        var_name = line[prefix_last_char_position:equal_char_position]
+        return var_name.strip()
+
+    cleaned_line_list = map(clean_line, env_line_list)
+    filtered_line_list = filter(is_hrflow_connectors_var, cleaned_line_list)
+    var_list_expected = map(remove_prefix, filtered_line_list)
+    var_list_expected = list(var_list_expected)
+    var_list_expected.sort()
+
+    # Get var list in Config
+    var_list_got = [var_name for var_name in config.__dict__]
+    var_list_got = list(var_list_got)
+    var_list_got.sort()
+
+    # Check var list
+    assert var_list_expected == var_list_got
+
+
+def test_Config_check_each_value(config):
+    # Get all environment variables
+    def is_hrflow_connectors_var(line):
+        return line.startswith("HRFLOW_CONNECTORS_")
+
+    def remove_prefix(line):
+        prefix_last_char_position = len("HRFLOW_CONNECTORS_")
+        return line[prefix_last_char_position:]
+
+    environement_var_list = [var_name for var_name in os.environ]
+    hrflow_connectors_var_list_expected = filter(
+        is_hrflow_connectors_var, environement_var_list
+    )
+    hrflow_connectors_var_list_expected = list(hrflow_connectors_var_list_expected)
+    
+    hrflow_connectors_var_expected = dict()
+    for var_name in hrflow_connectors_var_list_expected:
+        var_name_without_prefix = remove_prefix(var_name)
+        hrflow_connectors_var_expected[var_name_without_prefix] = os.environ[var_name]
+
+    # Get var in Config
+    hrflow_connectors_var_got = config.__dict__
+
+    # Check var
+    assert hrflow_connectors_var_expected == hrflow_connectors_var_got
+
+def test_Config_field_not_found(config):
+    try:
+        config.THIS_FIELD_DOES_NOT_EXIST
+        assert False
+    except ConfigError:
+        pass


### PR DESCRIPTION
This merge will :
* Move all credentials into environment variables that can be loaded from the `.env` file
* Create a `utils.config.Config` interface to retrieve the configuration from the environment
* Adapt all calls to connectors that need the config