### PR TITLE
feat: add '_' as valid token around date in main readme listing

### DIFF
--- a/src/hrflow_connectors/core/documentation.py
+++ b/src/hrflow_connectors/core/documentation.py
@@ -34,7 +34,7 @@ def CONNECTOR_LISTING_REGEXP_F(name: str) -> str:
     return (
         r"\|\s*\[?\*{0,2}(?i:(?P<name>"
         + r" ?".join([c for c in name if c.strip()])
-        + r"))\*{0,2}(\]\([^)]+\))?\s*\|[^|]+\|[^|]+\|\s*\*(?P<release_date>[\d\/]+)\*?\s*\|.+"
+        + r"))\*{0,2}(\]\([^)]+\))?\s*\|[^|]+\|[^|]+\|\s*(\*|_)(?P<release_date>[\d\/]+)(\*|_)\s*\|.+"
     )
 
 


### PR DESCRIPTION
It seems that auto formatting of markdown changes the actual '*' to '_' which causes make docs to fail. This fixes the issue by updating the finder regexp