### PR TITLE
fix: connectors github actions

### DIFF
--- a/.github/workflows/hrflow_connectors.yml
+++ b/.github/workflows/hrflow_connectors.yml
@@ -27,7 +27,7 @@ jobs:
           lfs: true
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.BASELINE_PYTHON_VERSION }}
 
@@ -61,6 +61,10 @@ jobs:
 
       - name: Run push hooks
         run: poetry run pre-commit run --show-diff-on-failure --hook-stage push --all-files
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
 
       # This action sets up a Python environment with Nox by:
       # - Activating every version of Python that GitHub Actions supports.
@@ -112,7 +116,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           lfs: true
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.BASELINE_PYTHON_VERSION }}
 
@@ -178,7 +182,7 @@ jobs:
           lfs: true
           persist-credentials: false
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.BASELINE_PYTHON_VERSION }}
 

--- a/.github/workflows/hrflow_connectors.yml
+++ b/.github/workflows/hrflow_connectors.yml
@@ -62,10 +62,6 @@ jobs:
       - name: Run push hooks
         run: poetry run pre-commit run --show-diff-on-failure --hook-stage push --all-files
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.9"
-
       # This action sets up a Python environment with Nox by:
       # - Activating every version of Python that GitHub Actions supports.
       # - Installing Nox.

--- a/.github/workflows/hrflow_connectors.yml
+++ b/.github/workflows/hrflow_connectors.yml
@@ -27,7 +27,7 @@ jobs:
           lfs: true
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.BASELINE_PYTHON_VERSION }}
 
@@ -112,7 +112,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           lfs: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.BASELINE_PYTHON_VERSION }}
 
@@ -178,7 +178,7 @@ jobs:
           lfs: true
           persist-credentials: false
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.BASELINE_PYTHON_VERSION }}
 

--- a/.github/workflows/hrflow_connectors.yml
+++ b/.github/workflows/hrflow_connectors.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Run Connector tests
         run: |
-          poetry run nox -- -s tests -- --no-cov --ignore tests/core --connector=SmartRecruiters --connector=PoleEmploi --connector=Adzuna --connector=Waalaxy --connector=Meteojob --connector=Jobology --connector=Carrevolutis
+          poetry run nox -- -s tests -- --no-cov --ignore tests/core --connector-v1=SmartRecruiters --connector-v1=PoleEmploi --connector-v1=Adzuna --connector-v1=Meteojob --connector-v1=Jobology --connector-v1=Carrevolutis --connector-v2=SmartRecruiters --connector-v2=Adzuna --connector-v2=Waalaxy
         env:
           HRFLOW_CONNECTORS_STORE_ENABLED: "1"
           HRFLOW_CONNECTORS_LOCALJSON_DIR: "/tmp/"

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,7 +16,7 @@ if t.TYPE_CHECKING:
 
 nox.options.reuse_existing_virtualenvs = True
 
-PYTHON_VERSIONS = ["3.9", "3.10", "3.11"]
+PYTHON_VERSIONS = ["3.10", "3.11"]
 REQUIREMENTS_CONTENT = {}
 
 

--- a/src/hrflow_connectors/v1/connectors/adzuna/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/adzuna/docs/pull_job_list.md
@@ -66,6 +66,7 @@ Retrieves jobs via the ***Adzuna'*** API Search endpointand send them to a ***Hr
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -128,6 +129,7 @@ Adzuna.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/breezyhr/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/breezyhr/docs/pull_job_list.md
@@ -32,6 +32,7 @@ Retrieves all jobs via the ***BreezyHR*** API and send them to a ***Hrflow.ai Bo
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -66,6 +67,7 @@ BreezyHR.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/bullhorn/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/bullhorn/docs/pull_job_list.md
@@ -36,6 +36,7 @@ Retrieves jobs from Bullhorn and writes them to Hrflow.ai Board
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -74,6 +75,7 @@ Bullhorn.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/ceridian/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/ceridian/docs/pull_job_list.md
@@ -34,6 +34,7 @@ Retrieves all jobs via the ***Ceridian*** API and send them to an ***Hrflow.ai B
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -70,6 +71,7 @@ Ceridian.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/digitalrecruiters/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/digitalrecruiters/docs/pull_job_list.md
@@ -36,6 +36,7 @@ Retrieves all jobs from Digital Recruiters and sends them to an Hrflow.ai Board.
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -68,6 +69,7 @@ DigitalRecruiters.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/greenhouse/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/greenhouse/docs/pull_job_list.md
@@ -35,6 +35,7 @@ Retrieves all jobs of a board via the ***Greenhouse*** API and send them to a **
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -66,6 +67,7 @@ Greenhouse.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/lever/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/lever/docs/pull_job_list.md
@@ -40,6 +40,7 @@ Retrieves all jobs via the Lever API and sends them to the Hrflow.ai Board.
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -76,6 +77,7 @@ Lever.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/recruitee/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/recruitee/docs/pull_job_list.md
@@ -34,6 +34,7 @@ Retrieves all jobs via the ***Recruitee*** API and send them to a ***Hrflow.ai B
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -70,6 +71,7 @@ Recruitee.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/salesforce/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/salesforce/docs/pull_job_list.md
@@ -34,6 +34,7 @@ Retrieves jobs from Salesforce HrFlow Job Custom Object and writes them to an Hr
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -70,6 +71,7 @@ Salesforce.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/sapsuccessfactors/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/sapsuccessfactors/docs/pull_job_list.md
@@ -34,6 +34,7 @@ Retrieves all jobs via the ***SAPSuccessFactors*** API and sends them to a ***Hr
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -70,6 +71,7 @@ SAPSuccessFactors.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/smartrecruiters/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/smartrecruiters/docs/pull_job_list.md
@@ -41,6 +41,7 @@ Retrieves all jobs via the ***SmartRecruiter*** API and send them to a ***Hrflow
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -77,6 +78,7 @@ SmartRecruiters.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/taleez/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/taleez/docs/pull_job_list.md
@@ -37,6 +37,7 @@ Retrieves all jobs via the ***Taleez*** API and send them to a ***Hrflow.ai Boar
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -70,6 +71,7 @@ Taleez.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/talentsoft/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/talentsoft/docs/pull_job_list.md
@@ -34,6 +34,7 @@ Retrieves jobs from TalentSoft vacancies export API and send them to a ***Hrflow
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -70,6 +71,7 @@ TalentSoft.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/teamtailor/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/teamtailor/docs/pull_job_list.md
@@ -32,6 +32,7 @@ Retrieve all jobs via the ***Teamtailor*** API and send them to an ***Hrflow.ai 
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -66,6 +67,7 @@ Teamtailor.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```

--- a/src/hrflow_connectors/v1/connectors/workable/docs/pull_job_list.md
+++ b/src/hrflow_connectors/v1/connectors/workable/docs/pull_job_list.md
@@ -30,6 +30,7 @@ Retrieves all jobs via the ***Workable*** API and send them to a ***Hrflow.ai Bo
 | `sync`  | `bool` | True | When enabled only pushed jobs will remain in the board |
 | `update_content`  | `bool` | False | When enabled jobs already present in the board are updated |
 | `enrich_with_parsing`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai parsing |
+| `enrich_with_parsing_v2`  | `bool` | False | When enabled jobs are enriched with HrFlow.ai Atlas parsing model. Uses the newer parsing API that returns a structured job object. Cannot be used together with enrich_with_parsing. |
 
 :red_circle: : *required*
 
@@ -62,6 +63,7 @@ Workable.pull_job_list(
         sync=True,
         update_content=False,
         enrich_with_parsing=False,
+        enrich_with_parsing_v2=False,
     )
 )
 ```


### PR DESCRIPTION
- **fixed core-tests workflow** 
> Dropped Python 3.9 from nox sessions: ubuntu-latest no longer ships CPython 3.9, so setup-nox resolves it to PyPy 3.9 which can't compile msgspec's C extension. CPython 3.9 is EOL since Oct 2025; manifest passes on 3.10 and 3.11.
[[all OSs] Python 3.9 will be removed](https://github.com/actions/runner-images/issues/13468)
- **fixed connectors-integration-tests**
test command needs to use the right flag names `--connector-v1` and `--connector-v2`